### PR TITLE
Connected with Firebase Analytics (GA)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.application"
     id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
+    id 'com.google.gms.google-services'
 }
 
 def localProperties = new Properties()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,11 @@ buildscript {
     }
 }
 
+plugins {
+  id 'com.google.gms.google-services' version '4.3.15' apply false
+}
+
+
 allprojects {
     repositories {
         google()

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,36 +1,84 @@
 PODS:
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+  - AppAuth (1.7.2):
+    - AppAuth/Core (= 1.7.2)
+    - AppAuth/ExternalUserAgent (= 1.7.2)
+  - AppAuth/Core (1.7.2)
+  - AppAuth/ExternalUserAgent (1.7.2):
     - AppAuth/Core
-  - Firebase/Auth (10.20.0):
+  - Firebase/Analytics (10.22.0):
+    - Firebase/Core
+  - Firebase/Auth (10.22.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.20.0)
-  - Firebase/CoreOnly (10.20.0):
-    - FirebaseCore (= 10.20.0)
-  - firebase_auth (4.17.6):
-    - Firebase/Auth (= 10.20.0)
+    - FirebaseAuth (~> 10.22.0)
+  - Firebase/Core (10.22.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (~> 10.22.0)
+  - Firebase/CoreOnly (10.22.0):
+    - FirebaseCore (= 10.22.0)
+  - Firebase/Messaging (10.22.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 10.22.0)
+  - firebase_analytics (10.8.9):
+    - Firebase/Analytics (= 10.22.0)
     - firebase_core
     - Flutter
-  - firebase_core (2.25.5):
-    - Firebase/CoreOnly (= 10.20.0)
+  - firebase_auth (4.17.6):
+    - Firebase/Auth (= 10.22.0)
+    - firebase_core
     - Flutter
-  - FirebaseAppCheckInterop (10.21.0)
-  - FirebaseAuth (10.20.0):
+  - firebase_core (2.27.0):
+    - Firebase/CoreOnly (= 10.22.0)
+    - Flutter
+  - firebase_messaging (14.7.19):
+    - Firebase/Messaging (= 10.22.0)
+    - firebase_core
+    - Flutter
+  - FirebaseAnalytics (10.22.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.22.0)
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (10.22.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleAppMeasurement (= 10.22.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseAppCheckInterop (10.22.0)
+  - FirebaseAuth (10.22.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseCore (10.20.0):
+  - FirebaseCore (10.22.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.21.0):
+  - FirebaseCoreInternal (10.22.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseInstallations (10.22.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - PromisesObjC (~> 2.1)
+  - FirebaseMessaging (10.22.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.3)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Reachability (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
   - Flutter (1.0.0)
   - flutter_inappwebview (0.0.1):
     - Flutter
@@ -50,6 +98,30 @@ PODS:
     - Flutter
     - FlutterMacOS
     - GoogleSignIn (~> 7.0)
+  - GoogleAppMeasurement (10.22.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.22.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (10.22.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.22.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.22.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - GoogleDataTransport (9.4.1):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
   - GoogleSignIn (7.0.0):
     - AppAuth (~> 1.5)
     - GTMAppAuth (< 3.0, >= 1.3)
@@ -65,6 +137,9 @@ PODS:
   - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (7.13.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
@@ -76,6 +151,9 @@ PODS:
   - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - GTMAppAuth (2.0.0):
     - AppAuth/Core (~> 1.6)
     - GTMSessionFetcher/Core (< 4.0, >= 1.5)
@@ -84,6 +162,11 @@ PODS:
     - Flutter
   - kakao_flutter_sdk_common (1.8.0):
     - Flutter
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
   - naveridlogin-sdk-ios (4.1.6)
   - OrderedSet (5.0.0)
   - path_provider_foundation (0.0.1):
@@ -96,8 +179,10 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_auth (from `.symlinks/plugins/firebase_auth/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview (from `.symlinks/plugins/flutter_inappwebview/ios`)
   - flutter_naver_login (from `.symlinks/plugins/flutter_naver_login/ios`)
@@ -113,24 +198,34 @@ SPEC REPOS:
   trunk:
     - AppAuth
     - Firebase
+    - FirebaseAnalytics
     - FirebaseAppCheckInterop
     - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - GoogleAppMeasurement
+    - GoogleDataTransport
     - GoogleSignIn
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
+    - nanopb
     - naveridlogin-sdk-ios
     - OrderedSet
     - PromisesObjC
     - RecaptchaInterop
 
 EXTERNAL SOURCES:
+  firebase_analytics:
+    :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_auth:
     :path: ".symlinks/plugins/firebase_auth/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_messaging:
+    :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
   flutter_inappwebview:
@@ -153,26 +248,34 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
 SPEC CHECKSUMS:
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
-  Firebase: 10c8cb12fb7ad2ae0c09ffc86cd9c1ab392a0031
-  firebase_auth: b237f065b2afc6bd7962124e1cbacdbef31036e6
-  firebase_core: c8628c7ce80f79439149549052bff22f6784fbf5
-  FirebaseAppCheckInterop: 69fc7d8f6a1cbfa973efb8d1723651de30d12525
-  FirebaseAuth: 9c5c400d2c3055d8ae3a0284944c86fa95d48dac
-  FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
-  FirebaseCoreInternal: 43c1788eaeee9d1b97caaa751af567ce11010d00
+  AppAuth: ca2458caccec349cc1e26d8d9e8fd7d22f1d01f3
+  Firebase: 797fd7297b7e1be954432743a0b3f90038e45a71
+  firebase_analytics: b9ce200bfc2c54629076bb22d6a510f31c296ab8
+  firebase_auth: 37f8f1cb18749323f2f4300504bfffae50271394
+  firebase_core: 100945864b4aedce3cfef0c62ab864858bf013cf
+  firebase_messaging: e65050bf9b187511d80ea3a4de7cf5573d2c7543
+  FirebaseAnalytics: 8d0ff929c63b7f72260f332b86ccf569776b75d3
+  FirebaseAppCheckInterop: 58db3e9494751399cf3e7b7e3e705cff71099153
+  FirebaseAuth: bbe4c68f958504ba9e54aee181adbdf5b664fbc6
+  FirebaseCore: 0326ec9b05fbed8f8716cddbf0e36894a13837f7
+  FirebaseCoreInternal: bca337352024b18424a61e478460547d46c4c753
+  FirebaseInstallations: 763814908793c0da14c18b3dcffdec71e29ed55e
+  FirebaseMessaging: 9f71037fd9db3376a4caa54e5a3949d1027b4b6e
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_inappwebview: 3d32228f1304635e7c028b0d4252937730bbc6cf
   flutter_naver_login: 1dbf6d21aae5235cdf76a28ac79cf6871899282f
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   geocoding_ios: a389ea40f6f548de6e63006a2e31bf66ff80769a
   google_sign_in_ios: 1bfaf6607b44cd1b24c4d4bc39719870440f9ce1
+  GoogleAppMeasurement: ccefe3eac9b0aa27f96066809fb1a7fe4b462626
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: 8a1b34ad97ebe6f909fb8b9b77fba99943007556
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
   kakao_flutter_sdk_common: f1f155e0e8a195ec73e0f69acc0b0af510a0e926
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
   naveridlogin-sdk-ios: cdd34e3585a3d5aaf37c1d84c1f41faba4a25d1a
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
@@ -180,6 +283,6 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
 
-PODFILE CHECKSUM: 70d9d25280d0dd177a5f637cdb0f0b0b12c6a189
+PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 
 COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -43,6 +43,16 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release-dev"

--- a/lib/GA/ga_route_observer.dart
+++ b/lib/GA/ga_route_observer.dart
@@ -1,0 +1,19 @@
+import 'package:child_goods_store_flutter/GA/google_analytics.dart';
+import 'package:child_goods_store_flutter/GA/models/ga_view_event.dart';
+import 'package:flutter/material.dart';
+
+class GARouteObserver extends NavigatorObserver {
+  @override
+  void didPush(Route route, Route? previousRoute) async {
+    super.didPush(route, previousRoute);
+
+    if (route.settings.name == null) return;
+
+    var viewEvent = GAViewEvent(
+      page: route.settings.name!,
+      id: (route.settings.arguments as Map<String, dynamic>?)?['id'] as int?,
+    );
+
+    await GoogleAnalytics.instance.pushPage(viewEvent);
+  }
+}

--- a/lib/GA/google_analytics.dart
+++ b/lib/GA/google_analytics.dart
@@ -1,3 +1,4 @@
+import 'package:child_goods_store_flutter/GA/models/ga_view_event.dart';
 import 'package:child_goods_store_flutter/enums/auth_method.dart';
 import 'package:child_goods_store_flutter/models/user/user_model.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
@@ -16,19 +17,9 @@ class GoogleAnalytics {
 
   bool _isSupported = false;
 
-  Future<void> initialize({
-    required int userId,
-  }) async {
+  Future<void> initialize() async {
     await _firebaseAnalytics.setAnalyticsCollectionEnabled(true);
     _isSupported = await _firebaseAnalytics.isSupported();
-    await _setUser(userId);
-  }
-
-  Future<void> _setUser(int userId) async {
-    if (_isSupported) {
-      await _firebaseAnalytics.setUserId(id: userId.toString());
-      debugPrint('[GA] Set user: $userId');
-    }
   }
 
   Future<void> login(EAuthMethod method) async {
@@ -39,11 +30,24 @@ class GoogleAnalytics {
   }
 
   Future<void> autoLogin(UserModel user) async {
-    if (_isSupported) {
+    if (_isSupported && user.userIdx != null) {
       await _firebaseAnalytics.logLogin(
-        parameters: user.toJson(),
+        parameters: {
+          'userId': user.userIdx!,
+          'eventAt': DateTime.now().toIso8601String(),
+        },
       );
       debugPrint('[GA] Auto login: User - ${user.nickName}(${user.userIdx})');
+    }
+  }
+
+  Future<void> pushPage(GAViewEvent event) async {
+    if (_isSupported) {
+      await _firebaseAnalytics.logScreenView(
+        screenName: event.page,
+        parameters: event.toJson(),
+      );
+      debugPrint('[GA] [VIEW]: ${event.toJson()}');
     }
   }
 }

--- a/lib/GA/models/ga_event_interface.dart
+++ b/lib/GA/models/ga_event_interface.dart
@@ -1,0 +1,14 @@
+import 'package:child_goods_store_flutter/blocs/auth/auth_bloc_singleton.dart';
+
+abstract class GAEvents {
+  final String type;
+  final int? userId;
+  final DateTime eventAt;
+
+  GAEvents({
+    required this.type,
+  })  : userId = AuthBlocSingleton.bloc.state.user?.userIdx,
+        eventAt = DateTime.now();
+
+  Map<String, dynamic> toJson();
+}

--- a/lib/GA/models/ga_view_event.dart
+++ b/lib/GA/models/ga_view_event.dart
@@ -1,0 +1,19 @@
+import 'package:child_goods_store_flutter/GA/models/ga_event_interface.dart';
+
+class GAViewEvent extends GAEvents {
+  final String page;
+  final int? id;
+
+  GAViewEvent({
+    required this.page,
+    this.id,
+  }) : super(type: 'VIEW');
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'userId': userId ?? -1,
+        'page': page,
+        'id': id ?? -1,
+        'eventAt': eventAt.toIso8601String(),
+      };
+}

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,3 +1,4 @@
+import 'package:child_goods_store_flutter/GA/ga_route_observer.dart';
 import 'package:child_goods_store_flutter/blocs/auth/auth_bloc_singleton.dart';
 import 'package:child_goods_store_flutter/blocs/child/child_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/edit_address/edit_address_bloc.dart';
@@ -42,9 +43,7 @@ import 'package:child_goods_store_flutter/repositories/data_repository.dart';
 import 'package:child_goods_store_flutter/repositories/image_repository.dart';
 import 'package:child_goods_store_flutter/repositories/search_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
-import 'package:child_goods_store_flutter/utils/google_analytics.dart';
 import 'package:child_goods_store_flutter/utils/page_transition.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -75,11 +74,7 @@ class _AppRouterState extends State<AppRouter> {
     _routerConfig = GoRouter(
       initialLocation: Routes.root,
       refreshListenable: AuthBlocSingleton.bloc,
-      observers: [
-        FirebaseAnalyticsObserver(
-          analytics: GoogleAnalytics.instance.firebaseInstance,
-        ),
-      ],
+      observers: [GARouteObserver()],
       redirect: (context, state) {
         final authState = AuthBlocSingleton.bloc.state;
         final allowPageInUnknownState = [Routes.signup, Routes.phoneVerify];
@@ -111,6 +106,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.root,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => SplashCubit(),
               child: const SplashPage(),
@@ -121,6 +117,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.signin,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: const SigninPage(),
           ),
         ),
@@ -128,6 +125,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.signup,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => SignupBloc(
                 authRepository: context.read<AuthRepository>(),
@@ -140,6 +138,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.phoneVerify,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => PhoneVerifyBloc(
                 authRepository: context.read<AuthRepository>(),
@@ -152,6 +151,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.editProfile,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => EditProfileBloc(
                 userRepository: context.read<UserRepository>(),
@@ -172,6 +172,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.editTag,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => EditTagBloc(
                 searchRepository: context.read<SearchRepository>(),
@@ -185,6 +186,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.editAddress,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => EditAddressBloc(
                 dataRepository: context.read<DataRepository>(),
@@ -204,6 +206,7 @@ class _AppRouterState extends State<AppRouter> {
           pageBuilder: (context, state, navigationShell) =>
               PageTransition.cupertino(
             key: state.pageKey,
+            // ignore `name` field for disable GA
             child: Scaffold(
               body: navigationShell,
               bottomNavigationBar: BottomNavigationBar(
@@ -246,6 +249,7 @@ class _AppRouterState extends State<AppRouter> {
             StatefulShellBranch(
               routes: [
                 GoRoute(
+                  name: Routes.home,
                   path: Routes.home,
                   builder: (context, state) => const HomePage(),
                 ),
@@ -254,6 +258,7 @@ class _AppRouterState extends State<AppRouter> {
             StatefulShellBranch(
               routes: [
                 GoRoute(
+                  name: Routes.together,
                   path: Routes.together,
                   builder: (context, state) => const TogetherPage(),
                 ),
@@ -262,6 +267,7 @@ class _AppRouterState extends State<AppRouter> {
             StatefulShellBranch(
               routes: [
                 GoRoute(
+                  name: Routes.child,
                   path: Routes.child,
                   builder: (context, state) => BlocProvider(
                     create: (context) => ChildBloc(
@@ -275,6 +281,7 @@ class _AppRouterState extends State<AppRouter> {
             StatefulShellBranch(
               routes: [
                 GoRoute(
+                  name: Routes.chat,
                   path: Routes.chat,
                   builder: (context, state) => const ChatPage(),
                 ),
@@ -283,6 +290,7 @@ class _AppRouterState extends State<AppRouter> {
             StatefulShellBranch(
               routes: [
                 GoRoute(
+                  name: Routes.profile,
                   path: Routes.profile,
                   builder: (context, state) => BlocProvider(
                     create: (context) => ProfileBloc(
@@ -302,6 +310,10 @@ class _AppRouterState extends State<AppRouter> {
           path: '${Routes.profile}/:userIdx',
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
+            arguments: {
+              'id': int.parse(state.pathParameters['userIdx'] as String),
+            },
             child: BlocProvider(
               create: (context) => ProfileBloc(
                 userRepository: context.read<UserRepository>(),
@@ -315,6 +327,10 @@ class _AppRouterState extends State<AppRouter> {
           path: '${Routes.follow}/:userIdx',
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
+            arguments: {
+              'id': int.parse(state.pathParameters['userIdx'] as String),
+            },
             child: BlocProvider(
               create: (context) => FollowBloc(
                 userRepository: context.read<UserRepository>(),
@@ -331,6 +347,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.editChild,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: BlocProvider(
               create: (context) => EditChildBloc(
                 childRepository: context.read<ChildRepository>(),
@@ -350,6 +367,7 @@ class _AppRouterState extends State<AppRouter> {
           path: Routes.settings,
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
+            name: state.fullPath,
             child: const SettingsPage(),
           ),
           routes: [
@@ -357,6 +375,7 @@ class _AppRouterState extends State<AppRouter> {
               path: SubRoutes.ship,
               pageBuilder: (context, state) => PageTransition.cupertino(
                 key: state.pageKey,
+                name: state.fullPath,
                 child: const ShipPage(),
               ),
             ),
@@ -364,6 +383,7 @@ class _AppRouterState extends State<AppRouter> {
               path: SubRoutes.notification,
               pageBuilder: (context, state) => PageTransition.cupertino(
                 key: state.pageKey,
+                name: state.fullPath,
                 child: const NotificationPage(),
               ),
             ),

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -42,7 +42,9 @@ import 'package:child_goods_store_flutter/repositories/data_repository.dart';
 import 'package:child_goods_store_flutter/repositories/image_repository.dart';
 import 'package:child_goods_store_flutter/repositories/search_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
+import 'package:child_goods_store_flutter/utils/google_analytics.dart';
 import 'package:child_goods_store_flutter/utils/page_transition.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -73,6 +75,11 @@ class _AppRouterState extends State<AppRouter> {
     _routerConfig = GoRouter(
       initialLocation: Routes.root,
       refreshListenable: AuthBlocSingleton.bloc,
+      observers: [
+        FirebaseAnalyticsObserver(
+          analytics: GoogleAnalytics.instance.firebaseInstance,
+        ),
+      ],
       redirect: (context, state) {
         final authState = AuthBlocSingleton.bloc.state;
         final allowPageInUnknownState = [Routes.signup, Routes.phoneVerify];

--- a/lib/blocs/auth/auth_bloc.dart
+++ b/lib/blocs/auth/auth_bloc.dart
@@ -8,7 +8,7 @@ import 'package:child_goods_store_flutter/enums/loading_status.dart';
 import 'package:child_goods_store_flutter/mixins/dio_exception_handler.dart';
 import 'package:child_goods_store_flutter/repositories/auth_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
-import 'package:child_goods_store_flutter/utils/google_analytics.dart';
+import 'package:child_goods_store_flutter/GA/google_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 

--- a/lib/blocs/auth/auth_bloc.dart
+++ b/lib/blocs/auth/auth_bloc.dart
@@ -8,6 +8,7 @@ import 'package:child_goods_store_flutter/enums/loading_status.dart';
 import 'package:child_goods_store_flutter/mixins/dio_exception_handler.dart';
 import 'package:child_goods_store_flutter/repositories/auth_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
+import 'package:child_goods_store_flutter/utils/google_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -95,6 +96,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState>
         }
         // Save jwt at secure_storage
         _saveJwt(jwt);
+        // LOGGING
+        GoogleAnalytics.instance.login(method);
         // Return to splash screen
         emit(const AuthState(
           status: ELoadingStatus.loaded,
@@ -180,6 +183,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState>
         }
         // Save jwt at secure_storage
         _saveJwt(jwt);
+        // LOGGING
+        GoogleAnalytics.instance.login(EAuthMethod.u3C1S);
         // Return to splash screen
         emit(const AuthState(
           status: ELoadingStatus.loaded,
@@ -230,6 +235,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState>
         if (res.data != null &&
             (res.data!.nickName == null ||
                 res.data!.nickName == Strings.nullStr)) {
+          // LOGGING
+          GoogleAnalytics.instance.autoLogin(res.data!);
           emit(AuthState(
             status: ELoadingStatus.loaded,
             authStatus: EAuthStatus.unAuthenticated,
@@ -238,6 +245,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState>
           return;
         }
         // Signin success
+        // LOGGING
+        GoogleAnalytics.instance.autoLogin(res.data!);
         emit(AuthState(
           status: ELoadingStatus.loaded,
           authStatus: EAuthStatus.authenticated,

--- a/lib/enums/auth_method.dart
+++ b/lib/enums/auth_method.dart
@@ -1,7 +1,8 @@
 enum EAuthMethod {
   google('Google', '구글'),
   naver('Naver', '네이버'),
-  kakao('Kakao', '카카오');
+  kakao('Kakao', '카카오'),
+  u3C1S('3C1S', '3C1S');
 
   final String key;
   final String ko;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,8 +19,17 @@
 
 import 'dart:async';
 import 'package:child_goods_store_flutter/app.dart';
+import 'package:child_goods_store_flutter/configs/firebase_options.dart';
+import 'package:child_goods_store_flutter/utils/google_analytics.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
 FutureOr<void> main() async {
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+
+  await GoogleAnalytics.instance.initialize(userId: 999);
+
   runApp(const App());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@
 import 'dart:async';
 import 'package:child_goods_store_flutter/app.dart';
 import 'package:child_goods_store_flutter/configs/firebase_options.dart';
-import 'package:child_goods_store_flutter/utils/google_analytics.dart';
+import 'package:child_goods_store_flutter/GA/google_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
@@ -29,7 +29,7 @@ FutureOr<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  await GoogleAnalytics.instance.initialize(userId: 999);
+  await GoogleAnalytics.instance.initialize();
 
   runApp(const App());
 }

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,7 +1,5 @@
 // Import from dev dependency
-import 'package:child_goods_store_flutter/configs/firebase_options_dev.dart';
 import 'package:child_goods_store_flutter/constants/secret.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
@@ -13,10 +11,6 @@ Future<void> main() async {
   F.appFlavor = Flavor.dev;
 
   WidgetsFlutterBinding.ensureInitialized();
-
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
 
   KakaoSdk.init(nativeAppKey: Secret.kakaoNativeAppKeyDev);
 

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -1,7 +1,5 @@
 // Import from prod dependency
-import 'package:child_goods_store_flutter/configs/firebase_options.dart';
 import 'package:child_goods_store_flutter/constants/secret.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
@@ -13,10 +11,6 @@ Future<void> main() async {
   F.appFlavor = Flavor.prod;
 
   WidgetsFlutterBinding.ensureInitialized();
-
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
 
   KakaoSdk.init(nativeAppKey: Secret.kakaoNativeAppKey);
 

--- a/lib/pages/edit_profile/edit_profile_page.dart
+++ b/lib/pages/edit_profile/edit_profile_page.dart
@@ -103,7 +103,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
         }
         if (state.status == ELoadingStatus.loaded) {
           if (context.read<EditProfileBloc>().httpMethod == EHttpMethod.post) {
-            context.replace(Routes.home);
+            context.pushReplacement(Routes.home);
           } else {
             context.pop();
           }

--- a/lib/pages/follow/widgets/follow_user_card.dart
+++ b/lib/pages/follow/widgets/follow_user_card.dart
@@ -18,7 +18,7 @@ class FollowUserCard extends StatelessWidget {
   });
 
   void _onUserTap(BuildContext context) {
-    context.replace('${Routes.profile}/${user.userIdx}');
+    context.pushReplacement('${Routes.profile}/${user.userIdx}');
   }
 
   @override

--- a/lib/pages/my_home_page.dart
+++ b/lib/pages/my_home_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import '../flavors.dart';
+
+class MyHomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(F.title),
+      ),
+      body: Center(
+        child: Text(
+          'Hello ${F.title}',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile/widgets/profile_card.dart
+++ b/lib/pages/profile/widgets/profile_card.dart
@@ -28,7 +28,7 @@ class ProfileCard extends StatelessWidget {
 
   void _onTapFollow(BuildContext context) {
     if (popAble) {
-      context.replace(
+      context.pushReplacement(
         '${Routes.follow}/${userProfile.userIdx}?mode=${EFollowMode.follower.key}',
       );
     } else {
@@ -40,7 +40,7 @@ class ProfileCard extends StatelessWidget {
 
   void _onTapFollowing(BuildContext context) {
     if (popAble) {
-      context.replace(
+      context.pushReplacement(
         '${Routes.follow}/${userProfile.userIdx}?mode=${EFollowMode.following.key}',
       );
     } else {

--- a/lib/pages/signin/widgets/oauth_button.dart
+++ b/lib/pages/signin/widgets/oauth_button.dart
@@ -30,6 +30,8 @@ class OauthButton extends StatelessWidget {
           Colors.white,
           BlendMode.srcIn,
         );
+      default:
+        return null;
     }
   }
 
@@ -41,6 +43,8 @@ class OauthButton extends StatelessWidget {
         return const Color(0xFFFEE500);
       case EAuthMethod.naver:
         return const Color(0xFF03C75A);
+      default:
+        return Colors.white;
     }
   }
 
@@ -52,6 +56,8 @@ class OauthButton extends StatelessWidget {
         return const Color.fromRGBO(0, 0, 0, 0.85);
       case EAuthMethod.naver:
         return Colors.white;
+      default:
+        return Colors.grey.shade800;
     }
   }
 

--- a/lib/utils/google_analytics.dart
+++ b/lib/utils/google_analytics.dart
@@ -1,0 +1,49 @@
+import 'package:child_goods_store_flutter/enums/auth_method.dart';
+import 'package:child_goods_store_flutter/models/user/user_model.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/material.dart';
+
+class GoogleAnalytics {
+  static final GoogleAnalytics _instance = GoogleAnalytics._();
+  static GoogleAnalytics get instance => _instance;
+
+  late final FirebaseAnalytics _firebaseAnalytics;
+  FirebaseAnalytics get firebaseInstance => _firebaseAnalytics;
+
+  GoogleAnalytics._() {
+    _firebaseAnalytics = FirebaseAnalytics.instance;
+  }
+
+  bool _isSupported = false;
+
+  Future<void> initialize({
+    required int userId,
+  }) async {
+    await _firebaseAnalytics.setAnalyticsCollectionEnabled(true);
+    _isSupported = await _firebaseAnalytics.isSupported();
+    await _setUser(userId);
+  }
+
+  Future<void> _setUser(int userId) async {
+    if (_isSupported) {
+      await _firebaseAnalytics.setUserId(id: userId.toString());
+      debugPrint('[GA] Set user: $userId');
+    }
+  }
+
+  Future<void> login(EAuthMethod method) async {
+    if (_isSupported) {
+      await _firebaseAnalytics.logLogin(loginMethod: method.key);
+      debugPrint('[GA] Login: Method - ${method.ko}');
+    }
+  }
+
+  Future<void> autoLogin(UserModel user) async {
+    if (_isSupported) {
+      await _firebaseAnalytics.logLogin(
+        parameters: user.toJson(),
+      );
+      debugPrint('[GA] Auto login: User - ${user.nickName}(${user.userIdx})');
+    }
+  }
+}

--- a/lib/utils/page_transition.dart
+++ b/lib/utils/page_transition.dart
@@ -4,10 +4,14 @@ import 'package:go_router/go_router.dart';
 class PageTransition {
   static CustomTransitionPage cupertino({
     LocalKey? key,
+    String? name,
+    Object? arguments,
     required Widget child,
   }) =>
       CustomTransitionPage(
         key: key,
+        name: name,
+        arguments: arguments,
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           return CupertinoPageTransition(
             primaryRouteAnimation: animation,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: fe4c077084ddda88f327dc1c96d16631cd68d4948644593fcbcd911c2c89e2fa
+      sha256: "4eec93681221723a686ad580c2e7d960e1017cf1a4e0a263c2573c2c6b0bf5cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.23"
+    version: "1.3.25"
   analyzer:
     dependency: transitive
     description:
@@ -305,6 +305,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.9.3+1"
+  firebase_analytics:
+    dependency: "direct main"
+    description:
+      name: firebase_analytics
+      sha256: b13cbf1ee78744ca5e6b762e9218db3bd3967a0edfed75f58339907892a2ccb9
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.8.9"
+  firebase_analytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_analytics_platform_interface
+      sha256: "416b33d62033db5ecd2df719fcb657ad04e9995fa0fc392ffdab4ca0e76cb679"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.9"
+  firebase_analytics_web:
+    dependency: transitive
+    description:
+      name: firebase_analytics_web
+      sha256: "9dca9d8d468172444ef18cabb73fe99f7aae24733bfad67115bd36bffd2d65c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.5+21"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -333,10 +357,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "797379ea206eaeeb62499775de812761493d0692890fdc7f90b6183a3369176d"
+      sha256: "53316975310c8af75a96e365f9fccb67d1c544ef0acdbf0d88bbe30eedd1c4f9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.25.5"
+    version: "2.27.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -353,6 +377,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.5"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: e41586e0fd04fe9a40424f8b0053d0832e6d04f49e020cdaf9919209a28497e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.7.19"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: f7a9d74ff7fc588a924f6b2eaeaa148b0db521b13a9db55f6ad45864fa98c06e
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.27"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: fc21e771166860c55b103701c5ac7cdb2eec28897b97c42e6e5703cbedf9e02e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.8"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   flutter_secure_storage: ^9.0.0
   firebase_core: ^2.25.5
   firebase_auth: ^4.17.6
+  firebase_analytics: ^10.8.9
+  firebase_messaging: ^14.7.19
   freezed_annotation: ^2.4.1
   json_annotation: ^4.8.1
   intl: ^0.18.1


### PR DESCRIPTION
### 개요

Firebase Analytics (이하 GA) 관련 설정 및 이벤트 처리 로직 구현 완료했습니다.

`dev` 환경에서만 디버그 뷰(실시간 이벤트 확인) 사용이 가능하고,
dev, prod 환경에서의 모든 이벤트는 GA에 수집됩니다.

또한, 1일에 1번 BigQuery로 GA 데이터를 export 하도록 설정하였으며, 현재 충분한 데이터가 모이지 않았고, 하루도 지나지 않았기 때문에 export 확인과 BE에서 활용 가능하도록 하는 문서 작업은 진행하지 못했습니다.

### 추가사항

- GAEvents
  이제 대부분의 GA 이벤트는 `GAEvents` abstract class의 상속 클래스로서 관리됩니다.
  현재는 `GAViewEvent` 가 구현되어있어, 페이지 이동에 대한 이벤트 처리를 담당하고 있습니다. (차후 GAPurchase, GALike 등 확장 가능)

- GoogleAnalytics singleton
  이벤트 등록 전 전처리와 GA 사용 여부를 판단하기 위해 `FirebaseAnalytics.instance` 대신 `GoogleAnalytics.singleton` 으로 자체 마이그레이션 하여 사용합니다.
  **초기화** 및 **login 이벤트**는 `AuthBloc` 에서 호출되고 있으며, **페이지 전환 이벤트**(`VIEW`)는 `GARouteObserver` 에서 호출되고 있습니다.

- GARouteObserver
  go_router의 observers 에 등록된 옵저버 클래스로 페이지가 전환되면 didPush 메서드 내부에서 GA 페이지 전환 이벤트(`VIEW`)를 등록합니다.

### 변경사항 및 이유

- iOS 최소 빌드 버전이 9.0 에서 `12.0` 으로 변경
  대부분의 라이브러리들이 12.0 버전 이상을 권장하는 warning이 발생하여 일괄적으로 12.0으로 버전 업

- `EAuthMethod`에 `u3C1S` 추가
  GA의 login 이벤트를 일괄적으로 관리하기 위해 EAuthMethod enum에 자체 로그인 타입 u3C1S를 추가
  (u를 붙인 이유는 숫자로 시작하면 안되기 때문)

- context.replace 대신 `pushReplacement`
  원인 파악은 되지 않았으나, goRouter 사용 시 NavigatorObserver의 didReplace 메서드가 context.replace 에서 동작하지 않음.
  따라서 대안으로 pushReplacement 사용 (디자인적으로도 더욱 만족)