### PR TITLE
Feat: "Replace phone verify to email verify"

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,5 +31,6 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    - lib/repositories/ # TODO: delete after connect api
   errors:
     invalid_annotation_target: ignore

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -6,7 +6,6 @@ import 'package:child_goods_store_flutter/blocs/edit_child/edit_child_bloc.dart'
 import 'package:child_goods_store_flutter/blocs/edit_profile/edit_profile_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/edit_tag/edit_tag_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/follow/follow_bloc.dart';
-import 'package:child_goods_store_flutter/blocs/phone_verify/phone_verify_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/profile/profile_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/signup/signup_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/splash/splash_cubit.dart';
@@ -29,7 +28,6 @@ import 'package:child_goods_store_flutter/pages/edit_tag/edit_tag_page.dart';
 import 'package:child_goods_store_flutter/pages/follow/follow_page.dart';
 import 'package:child_goods_store_flutter/pages/home/home_page.dart';
 import 'package:child_goods_store_flutter/pages/notification/notification_page.dart';
-import 'package:child_goods_store_flutter/pages/phone_verify/phone_verify_page.dart';
 import 'package:child_goods_store_flutter/pages/profile/profile_page.dart';
 import 'package:child_goods_store_flutter/pages/settings/settings_page.dart';
 import 'package:child_goods_store_flutter/pages/ship/ship_page.dart';
@@ -77,8 +75,8 @@ class _AppRouterState extends State<AppRouter> {
       observers: [GARouteObserver()],
       redirect: (context, state) {
         final authState = AuthBlocSingleton.bloc.state;
-        final allowPageInUnknownState = [Routes.signup, Routes.phoneVerify];
-        final allowPageInUnAuthState = [Routes.phoneVerify];
+        final allowPageInUnknownState = [Routes.signup]; // Routes.phoneVerify
+        final allowPageInUnAuthState = []; // Routes.phoneVerify
         final blockPageInAuthState = [Routes.root, Routes.signin];
 
         if (authState.authStatus == EAuthStatus.init) {
@@ -134,19 +132,19 @@ class _AppRouterState extends State<AppRouter> {
             ),
           ),
         ),
-        GoRoute(
-          path: Routes.phoneVerify,
-          pageBuilder: (context, state) => PageTransition.cupertino(
-            key: state.pageKey,
-            name: state.fullPath,
-            child: BlocProvider(
-              create: (context) => PhoneVerifyBloc(
-                authRepository: context.read<AuthRepository>(),
-              ),
-              child: const PhoneVerifyPage(),
-            ),
-          ),
-        ),
+        // GoRoute(
+        //   path: Routes.phoneVerify,
+        //   pageBuilder: (context, state) => PageTransition.cupertino(
+        //     key: state.pageKey,
+        //     name: state.fullPath,
+        //     child: BlocProvider(
+        //       create: (context) => PhoneVerifyBloc(
+        //         authRepository: context.read<AuthRepository>(),
+        //       ),
+        //       child: const PhoneVerifyPage(),
+        //     ),
+        //   ),
+        // ),
         GoRoute(
           path: Routes.editProfile,
           pageBuilder: (context, state) => PageTransition.cupertino(

--- a/lib/blocs/signup/signup_event.dart
+++ b/lib/blocs/signup/signup_event.dart
@@ -18,10 +18,19 @@ class SignupChangePWCheck extends SignupEvent {
   SignupChangePWCheck(this.passwordCheck);
 }
 
-class SignupChangePhoneNum extends SignupEvent {
-  final String phoneNum;
+class SignupChangeSendCode extends SignupEvent {}
 
-  SignupChangePhoneNum(this.phoneNum);
+class SignupChangeVerifyCode extends SignupEvent {
+  final String code;
+
+  SignupChangeVerifyCode(this.code);
 }
+
+// @Deprecated('phone verify is deprecated')
+// class SignupChangePhoneNum extends SignupEvent {
+//   final String phoneNum;
+
+//   SignupChangePhoneNum(this.phoneNum);
+// }
 
 class SignupSubmit extends SignupEvent {}

--- a/lib/blocs/signup/signup_state.dart
+++ b/lib/blocs/signup/signup_state.dart
@@ -5,13 +5,25 @@ class SignupState extends BlocState {
   final String? email;
   final String? password;
   final String? passwordCheck;
-  final String? phoneNum;
+  final ELoadingStatus sendStatus;
+  final ELoadingStatus verifyStatus;
+
+  /// `verifiedEmail == email` -> verified \
+  /// `else` -> not verified
+  final String? verifiedEmail;
+  final ELoadingStatus submitStatus;
+
+  // final String? phoneNum;
 
   const SignupState({
     this.email,
     this.password,
     this.passwordCheck,
-    this.phoneNum,
+    required this.sendStatus,
+    required this.verifyStatus,
+    this.verifiedEmail,
+    required this.submitStatus,
+    // this.phoneNum,
     required super.status,
     super.message,
   });
@@ -20,7 +32,11 @@ class SignupState extends BlocState {
       : email = null,
         password = null,
         passwordCheck = null,
-        phoneNum = null,
+        sendStatus = ELoadingStatus.init,
+        verifyStatus = ELoadingStatus.init,
+        verifiedEmail = null,
+        submitStatus = ELoadingStatus.init,
+        // phoneNum = null,
         super(
           status: ELoadingStatus.init,
           message: null,
@@ -33,13 +49,21 @@ class SignupState extends BlocState {
     String? email,
     String? password,
     String? passwordCheck,
-    String? phoneNum,
+    ELoadingStatus? sendStatus,
+    ELoadingStatus? verifyStatus,
+    String? verifiedEmail,
+    ELoadingStatus? submitStatus,
+    // String? phoneNum,
   }) =>
       SignupState(
         email: email ?? this.email,
         password: password ?? this.password,
         passwordCheck: passwordCheck ?? this.passwordCheck,
-        phoneNum: phoneNum ?? this.phoneNum,
+        sendStatus: sendStatus ?? this.sendStatus,
+        verifyStatus: verifyStatus ?? this.verifyStatus,
+        verifiedEmail: verifiedEmail ?? this.verifiedEmail,
+        submitStatus: submitStatus ?? this.submitStatus,
+        // phoneNum: phoneNum ?? this.phoneNum,
         status: status ?? this.status,
         message: message ?? this.message,
       );
@@ -49,7 +73,11 @@ class SignupState extends BlocState {
         email,
         password,
         passwordCheck,
-        phoneNum,
+        sendStatus,
+        verifyStatus,
+        verifiedEmail,
+        submitStatus,
+        // phoneNum,
         status,
         message,
       ];

--- a/lib/constants/routes.dart
+++ b/lib/constants/routes.dart
@@ -3,7 +3,7 @@ class Routes {
   static const String signin = '/signin';
   static const String signup = '/signup';
 
-  static const String phoneVerify = '/phone_verify';
+  // static const String phoneVerify = '/phone_verify'; // deprecated
 
   static const String settings = '/settings';
 

--- a/lib/pages/edit_profile/edit_profile_page.dart
+++ b/lib/pages/edit_profile/edit_profile_page.dart
@@ -68,12 +68,13 @@ class _EditProfilePageState extends State<EditProfilePage> {
     context.read<EditProfileBloc>().add(EditProfileChangeIntroduce(introduce));
   }
 
-  void _onTapPhone() async {
-    var phoneNum = await context.push<String?>(Routes.phoneVerify);
-    if (phoneNum != null && mounted) {
-      context.read<EditProfileBloc>().add(EditProfileChangePhoneNum(phoneNum));
-    }
-  }
+  // @Deprecated('phone verify is deprecated')
+  // void _onTapPhone() async {
+  //   var phoneNum = await context.push<String?>(Routes.phoneVerify);
+  //   if (phoneNum != null && mounted) {
+  //     context.read<EditProfileBloc>().add(EditProfileChangePhoneNum(phoneNum));
+  //   }
+  // }
 
   void _onChangedRegion(String? region) {
     context
@@ -179,28 +180,6 @@ class _EditProfilePageState extends State<EditProfilePage> {
                   controller: _introduceController,
                   onChange: _onIntroduceChange,
                   hasNext: true,
-                ),
-                Gaps.v20,
-                Row(
-                  children: [
-                    Expanded(
-                      child: BlocBuilder<EditProfileBloc, EditProfileState>(
-                        builder: (context, state) => AppFont(
-                          state.user.phoneNum?.isNotEmpty == true
-                              ? state.user.phoneNum!
-                              : '번호를 변경해주세요.',
-                          fontSize: Sizes.size16,
-                        ),
-                      ),
-                    ),
-                    AppInkButton(
-                      onTap: _onTapPhone,
-                      child: const AppFont(
-                        '번호 변경',
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
                 ),
                 Gaps.v20,
                 const AppFont(

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -142,15 +142,15 @@ class AuthRepository {
     return res;
   }
 
-  Future<ResModel<void>> postPhoneSend({
-    required String phoneNum,
+  Future<ResModel<void>> postEmailSend({
+    required String email,
   }) async {
     // Dio dio = Dio();
     // dio.interceptors.add(UnAuthInterceptor());
     // dio.post(
-    //   '/phone/send',
+    //   '/email/send',
     //   data: {
-    //     'phoneNum': phoneNum,
+    //     'email': email,
     //   },
     // );
 
@@ -164,15 +164,17 @@ class AuthRepository {
     return res;
   }
 
-  Future<ResModel<void>> postPhoneVerify({
+  Future<ResModel<void>> postEmailVerify({
+    required String email,
     required String code,
   }) async {
     // Dio dio = Dio();
     // dio.interceptors.add(UnAuthInterceptor());
     // dio.post(
-    //   '/phone/verify',
+    //   '/email/verify',
     //   data: {
-    //     'code': code,
+    //     'email': email,
+    //     'authNum': code,
     //   },
     // );
 
@@ -189,7 +191,7 @@ class AuthRepository {
   Future<ResModel<void>> postSignup({
     required String email,
     required String password,
-    required String phoneNum,
+    // required String phoneNum,
   }) async {
     // Dio dio = Dio();
     // dio.interceptors.add(UnAuthInterceptor());


### PR DESCRIPTION
### 개요

Resolves: #12

### 추가사항

- 이메일 인증 화면 구현
- 이메일 인증 API mocking

### 변경사항 및 이유

- phone_verify deprecated (혹시 모르니 코드는 삭제하지 않고 주석처리)
- signup_bloc status 세분화
  인증번호 발송, 인증, 회원가입 처리 로딩 상태 처리를 위한 status를 3개로 세분화 하였습니다.