### PR TITLE
Fix: "hotfix for deprecated phone_verify_bloc"

### DIFF
--- a/lib/blocs/phone_verify/phone_verify_bloc.dart
+++ b/lib/blocs/phone_verify/phone_verify_bloc.dart
@@ -56,7 +56,7 @@ class PhoneVerifyBloc extends Bloc<PhoneVerifyEvent, PhoneVerifyState>
             emit(state.copyWith(status: ELoadingStatus.init));
             return;
           }
-          await authRepository.postPhoneSend(phoneNum: state.phoneNum!);
+          // await authRepository.postPhoneSend(phoneNum: state.phoneNum!);
           emit(state.copyWith(
             status: ELoadingStatus.loaded,
             phoneStatus: ELoadingStatus.loaded,
@@ -71,7 +71,7 @@ class PhoneVerifyBloc extends Bloc<PhoneVerifyEvent, PhoneVerifyState>
             emit(state.copyWith(status: ELoadingStatus.init));
             return;
           }
-          await authRepository.postPhoneVerify(code: state.code!);
+          // await authRepository.postPhoneVerify(code: state.code!);
           emit(state.copyWith(
             status: ELoadingStatus.loaded,
             codeStatus: ELoadingStatus.loaded,


### PR DESCRIPTION
### 개요

해당 bloc에서 더이상 인터페이스가 없은 authRepository의 함수에 접근하는 코드를 주석처리 하였습니다.

### 추가사항

N/A

### 변경사항 및 이유

- PhoneVerifyBloc 에서 authRepository에 접근하는 코드 주석처리