### PR TITLE
Implement profile page tabs

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:child_goods_store_flutter/repositories/child_repository.dart';
 import 'package:child_goods_store_flutter/repositories/data_repository.dart';
 import 'package:child_goods_store_flutter/repositories/image_repository.dart';
 import 'package:child_goods_store_flutter/repositories/product_repository.dart';
+import 'package:child_goods_store_flutter/repositories/profile_repository.dart';
 import 'package:child_goods_store_flutter/repositories/search_repository.dart';
 import 'package:child_goods_store_flutter/repositories/together_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
@@ -32,6 +33,9 @@ class App extends StatelessWidget {
         ),
         RepositoryProvider(
           create: (context) => TogetherRepository(),
+        ),
+        RepositoryProvider(
+          create: (context) => ProfileRepository(),
         ),
         RepositoryProvider(
           create: (context) => ImageRepository(),

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -567,6 +567,7 @@ class _AppRouterState extends State<AppRouter> {
         appBarTheme: const AppBarTheme(
           centerTitle: false,
           surfaceTintColor: Colors.transparent,
+          backgroundColor: Colors.white,
           shadowColor: Colors.black,
           scrolledUnderElevation: Sizes.size1,
           titleTextStyle: TextStyle(
@@ -589,6 +590,7 @@ class _AppRouterState extends State<AppRouter> {
       locale: const Locale('ko'),
       builder: (context, child) => _flavorBanner(
         child: child ?? const SizedBox(),
+        show: F.appFlavor != Flavor.prod,
       ),
     );
   }

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -11,6 +11,7 @@ import 'package:child_goods_store_flutter/blocs/follow/follow_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/product/detail/product_detail_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/product/list/product_list_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/profile/profile_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/signup/signup_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/splash/splash_cubit.dart';
 import 'package:child_goods_store_flutter/blocs/together/detail/together_detail_bloc.dart';
@@ -52,6 +53,7 @@ import 'package:child_goods_store_flutter/repositories/child_repository.dart';
 import 'package:child_goods_store_flutter/repositories/data_repository.dart';
 import 'package:child_goods_store_flutter/repositories/image_repository.dart';
 import 'package:child_goods_store_flutter/repositories/product_repository.dart';
+import 'package:child_goods_store_flutter/repositories/profile_repository.dart';
 import 'package:child_goods_store_flutter/repositories/search_repository.dart';
 import 'package:child_goods_store_flutter/repositories/together_repository.dart';
 import 'package:child_goods_store_flutter/repositories/user_repository.dart';
@@ -326,11 +328,21 @@ class _AppRouterState extends State<AppRouter> {
                 GoRoute(
                   name: Routes.profile,
                   path: Routes.profile,
-                  builder: (context, state) => BlocProvider(
-                    create: (context) => ProfileBloc(
-                      userRepository: context.read<UserRepository>(),
-                      userId: AuthBlocSingleton.bloc.state.user!.userId!,
-                    ),
+                  builder: (context, state) => MultiBlocProvider(
+                    providers: [
+                      BlocProvider(
+                        create: (context) => ProfileBloc(
+                          userRepository: context.read<UserRepository>(),
+                          userId: AuthBlocSingleton.bloc.state.user!.userId!,
+                        ),
+                      ),
+                      BlocProvider(
+                        create: (context) => ProfileTabBloc(
+                          profileRepository: context.read<ProfileRepository>(),
+                          userId: AuthBlocSingleton.bloc.state.user!.userId!,
+                        ),
+                      ),
+                    ],
                     child: const ProfilePage(
                       popAble: false,
                     ),
@@ -384,12 +396,24 @@ class _AppRouterState extends State<AppRouter> {
             arguments: {
               'id': int.parse(state.pathParameters['userId'] as String),
             },
-            child: BlocProvider(
-              create: (context) => ProfileBloc(
-                userRepository: context.read<UserRepository>(),
-                userId: int.parse(state.pathParameters['userId'] as String),
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider(
+                  create: (context) => ProfileBloc(
+                    userRepository: context.read<UserRepository>(),
+                    userId: int.parse(state.pathParameters['userId'] as String),
+                  ),
+                ),
+                BlocProvider(
+                  create: (context) => ProfileTabBloc(
+                    profileRepository: context.read<ProfileRepository>(),
+                    userId: int.parse(state.pathParameters['userId'] as String),
+                  ),
+                ),
+              ],
+              child: const ProfilePage(
+                popAble: true,
               ),
-              child: const ProfilePage(popAble: true),
             ),
           ),
         ),

--- a/lib/blocs/product/buyer/product_buyer_bloc.dart
+++ b/lib/blocs/product/buyer/product_buyer_bloc.dart
@@ -15,8 +15,6 @@ class ProductBuyerBloc extends Bloc<ProductBuyerEvent, ProductBuyerState>
     required this.productId,
   }) : super(const ProductBuyerState.init()) {
     on<ProductBuyerGet>(_productBuyerGetHandler);
-
-    add(ProductBuyerGet());
   }
 
   Future<void> _productBuyerGetHandler(

--- a/lib/blocs/profile/profile_tab_bloc.dart
+++ b/lib/blocs/profile/profile_tab_bloc.dart
@@ -17,7 +17,6 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
     required this.profileRepository,
     required this.userId,
   }) : super(const ProfileTabState.init()) {
-    on<ProfileTabScroll>(_profileTabScrollHandler);
     on<ProfileTabChangeCategory>(_profileTabChangeCategoryHandler);
     on<ProfileTabGetProducts>(_profileTabGetProductsHandler);
     on<ProfileTabGetTogethers>(_profileTabGetTogethersHandler);
@@ -26,19 +25,6 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
     on<ProfileTabGetPurchaseProducts>(_profileTabGetPurchaseProductsHandler);
     on<ProfileTabGetPurchaseTogethers>(_profileTabGetPurchaseTogethersHandler);
   }
-
-  Future<void> _profileTabScrollHandler(
-    ProfileTabScroll event,
-    Emitter<ProfileTabState> emit,
-  ) async {
-    emit(state.copyWith(
-      outerScrollPos: event.outerScrollPos,
-      myScrollPos: event.myScrollPos,
-      heartScrollPos: event.heartScrollPos,
-      purchaseScrollPos: event.purchaseScrollPos,
-    ));
-  }
-
   Future<void> _profileTabChangeCategoryHandler(
     ProfileTabChangeCategory event,
     Emitter<ProfileTabState> emit,

--- a/lib/blocs/profile/profile_tab_bloc.dart
+++ b/lib/blocs/profile/profile_tab_bloc.dart
@@ -1,0 +1,244 @@
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_event.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_state.dart';
+import 'package:child_goods_store_flutter/enums/loading_status.dart';
+import 'package:child_goods_store_flutter/mixins/dio_exception_handler.dart';
+import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
+import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
+import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:child_goods_store_flutter/repositories/profile_repository.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
+    with DioExceptionHandlerMixin {
+  final ProfileRepository profileRepository;
+  final int userId;
+
+  ProfileTabBloc({
+    required this.profileRepository,
+    required this.userId,
+  }) : super(const ProfileTabState.init()) {
+    on<ProfileTabScroll>(_profileTabScrollHandler);
+    on<ProfileTabChangeCategory>(_profileTabChangeCategoryHandler);
+    on<ProfileTabGetProducts>(_profileTabGetProductsHandler);
+    on<ProfileTabGetTogethers>(_profileTabGetTogethersHandler);
+    on<ProfileTabGetHeartProducts>(_profileTabGetHeartProductsHandler);
+    on<ProfileTabGetHeartTogethers>(_profileTabGetHeartTogethersHandler);
+    on<ProfileTabGetPurchaseProducts>(_profileTabGetPurchaseProductsHandler);
+    on<ProfileTabGetPurchaseTogethers>(_profileTabGetPurchaseTogethersHandler);
+  }
+
+  Future<void> _profileTabScrollHandler(
+    ProfileTabScroll event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    emit(state.copyWith(
+      outerScrollPos: event.outerScrollPos,
+      myScrollPos: event.myScrollPos,
+      heartScrollPos: event.heartScrollPos,
+      purchaseScrollPos: event.purchaseScrollPos,
+    ));
+  }
+
+  Future<void> _profileTabChangeCategoryHandler(
+    ProfileTabChangeCategory event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    emit(state.copyWith(category: event.category));
+  }
+
+  Future<void> _profileTabGetProductsHandler(
+    ProfileTabGetProducts event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.myProductsStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      myProductsStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileProductList(
+          userId: userId,
+        );
+
+        List<ProductPreviewModel> newList = [];
+        newList
+          ..addAll(state.myProducts)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          myProductsStatus: ELoadingStatus.loaded,
+          myProducts: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+
+  Future<void> _profileTabGetTogethersHandler(
+    ProfileTabGetTogethers event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.myTogethersStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      myTogethersStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileTogetherList(
+          userId: userId,
+        );
+
+        List<TogetherPreviewModel> newList = [];
+        newList
+          ..addAll(state.myTogethers)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          myTogethersStatus: ELoadingStatus.loaded,
+          myTogethers: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+
+  Future<void> _profileTabGetHeartProductsHandler(
+    ProfileTabGetHeartProducts event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.heartProductsStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      heartProductsStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileProductHeartList();
+
+        List<ProductPreviewModel> newList = [];
+        newList
+          ..addAll(state.heartProducts)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          heartProductsStatus: ELoadingStatus.loaded,
+          heartProducts: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+
+  Future<void> _profileTabGetHeartTogethersHandler(
+    ProfileTabGetHeartTogethers event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.heartTogethersStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      heartTogethersStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileTogetherHeartList();
+
+        List<TogetherPreviewModel> newList = [];
+        newList
+          ..addAll(state.heartTogethers)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          heartTogethersStatus: ELoadingStatus.loaded,
+          heartTogethers: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+
+  Future<void> _profileTabGetPurchaseProductsHandler(
+    ProfileTabGetPurchaseProducts event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.purchaseProductsStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      purchaseProductsStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileProductPurchaseList();
+
+        List<PurchaseModel> newList = [];
+        newList
+          ..addAll(state.purchaseProducts)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          purchaseProductsStatus: ELoadingStatus.loaded,
+          purchaseProducts: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+
+  Future<void> _profileTabGetPurchaseTogethersHandler(
+    ProfileTabGetPurchaseTogethers event,
+    Emitter<ProfileTabState> emit,
+  ) async {
+    if (state.status == ELoadingStatus.loading &&
+        state.purchaseTogethersStatus == ELoadingStatus.loading) return;
+
+    emit(state.copyWith(
+      status: ELoadingStatus.loading,
+      purchaseTogethersStatus: ELoadingStatus.loading,
+    ));
+    await handleApiRequest(
+      () async {
+        var res = await profileRepository.getProfileTogetherPurchaseList();
+
+        List<PurchaseModel> newList = [];
+        newList
+          ..addAll(state.purchaseTogethers)
+          ..addAll(res.data ?? []);
+
+        emit(state.copyWith(
+          status: ELoadingStatus.loaded,
+          purchaseTogethersStatus: ELoadingStatus.loaded,
+          purchaseTogethers: newList,
+        ));
+      },
+      state: state,
+      emit: emit,
+      initAfterError: false,
+    );
+  }
+}

--- a/lib/blocs/profile/profile_tab_bloc.dart
+++ b/lib/blocs/profile/profile_tab_bloc.dart
@@ -63,6 +63,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            myProductsStatus: ELoadingStatus.error,
+            myProductsMessage: state.message,
+          ));
+        }
+      },
     );
   }
 
@@ -97,6 +105,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            myTogethersStatus: ELoadingStatus.error,
+            myTogethersMessage: state.message,
+          ));
+        }
+      },
     );
   }
 
@@ -129,6 +145,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            heartProductsStatus: ELoadingStatus.error,
+            heartProductsMessage: state.message,
+          ));
+        }
+      },
     );
   }
 
@@ -161,6 +185,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            heartTogethersStatus: ELoadingStatus.error,
+            heartTogethersMessage: state.message,
+          ));
+        }
+      },
     );
   }
 
@@ -193,6 +225,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            purchaseProductsStatus: ELoadingStatus.error,
+            purchaseProductsMessage: state.message,
+          ));
+        }
+      },
     );
   }
 
@@ -225,6 +265,14 @@ class ProfileTabBloc extends Bloc<ProfileTabEvent, ProfileTabState>
       state: state,
       emit: emit,
       initAfterError: false,
+      finallyCall: () async {
+        if (state.status == ELoadingStatus.error) {
+          emit(state.copyWith(
+            purchaseTogethersStatus: ELoadingStatus.error,
+            purchaseTogethersMessage: state.message,
+          ));
+        }
+      },
     );
   }
 }

--- a/lib/blocs/profile/profile_tab_event.dart
+++ b/lib/blocs/profile/profile_tab_event.dart
@@ -1,0 +1,35 @@
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+
+abstract class ProfileTabEvent {}
+
+class ProfileTabScroll extends ProfileTabEvent {
+  final double? outerScrollPos;
+  final double? myScrollPos;
+  final double? heartScrollPos;
+  final double? purchaseScrollPos;
+
+  ProfileTabScroll({
+    this.outerScrollPos,
+    this.myScrollPos,
+    this.heartScrollPos,
+    this.purchaseScrollPos,
+  });
+}
+
+class ProfileTabChangeCategory extends ProfileTabEvent {
+  final EChatItemType category;
+
+  ProfileTabChangeCategory(this.category);
+}
+
+class ProfileTabGetProducts extends ProfileTabEvent {}
+
+class ProfileTabGetTogethers extends ProfileTabEvent {}
+
+class ProfileTabGetHeartProducts extends ProfileTabEvent {}
+
+class ProfileTabGetHeartTogethers extends ProfileTabEvent {}
+
+class ProfileTabGetPurchaseProducts extends ProfileTabEvent {}
+
+class ProfileTabGetPurchaseTogethers extends ProfileTabEvent {}

--- a/lib/blocs/profile/profile_tab_event.dart
+++ b/lib/blocs/profile/profile_tab_event.dart
@@ -2,20 +2,6 @@ import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
 
 abstract class ProfileTabEvent {}
 
-class ProfileTabScroll extends ProfileTabEvent {
-  final double? outerScrollPos;
-  final double? myScrollPos;
-  final double? heartScrollPos;
-  final double? purchaseScrollPos;
-
-  ProfileTabScroll({
-    this.outerScrollPos,
-    this.myScrollPos,
-    this.heartScrollPos,
-    this.purchaseScrollPos,
-  });
-}
-
 class ProfileTabChangeCategory extends ProfileTabEvent {
   final EChatItemType category;
 

--- a/lib/blocs/profile/profile_tab_state.dart
+++ b/lib/blocs/profile/profile_tab_state.dart
@@ -9,53 +9,87 @@ class ProfileTabState extends BlocState {
   final EChatItemType category;
 
   final ELoadingStatus myProductsStatus;
+  final String? myProductsMessage;
   final List<ProductPreviewModel> myProducts;
+
   final ELoadingStatus myTogethersStatus;
+  final String? myTogethersMessage;
   final List<TogetherPreviewModel> myTogethers;
 
   final ELoadingStatus heartProductsStatus;
+  final String? heartProductsMessage;
   final List<ProductPreviewModel> heartProducts;
+
   final ELoadingStatus heartTogethersStatus;
+  final String? heartTogethersMessage;
   final List<TogetherPreviewModel> heartTogethers;
 
   final ELoadingStatus purchaseProductsStatus;
+  final String? purchaseProductsMessage;
   final List<PurchaseModel> purchaseProducts;
+
   final ELoadingStatus purchaseTogethersStatus;
+  final String? purchaseTogethersMessage;
   final List<PurchaseModel> purchaseTogethers;
 
   // TODO: review list
 
   const ProfileTabState({
     required this.category,
+    //
     required this.myProductsStatus,
+    this.myProductsMessage,
     required this.myProducts,
+    //
     required this.myTogethersStatus,
+    this.myTogethersMessage,
     required this.myTogethers,
+    //
     required this.heartProductsStatus,
+    this.heartProductsMessage,
     required this.heartProducts,
+    //
     required this.heartTogethersStatus,
+    this.heartTogethersMessage,
     required this.heartTogethers,
+    //
     required this.purchaseProductsStatus,
+    this.purchaseProductsMessage,
     required this.purchaseProducts,
+    //
     required this.purchaseTogethersStatus,
+    this.purchaseTogethersMessage,
     required this.purchaseTogethers,
+    //
     required super.status,
     super.message,
   });
 
   const ProfileTabState.init()
       : category = EChatItemType.product,
+        //
         myProductsStatus = ELoadingStatus.init,
+        myProductsMessage = null,
         myProducts = const [],
+        //
         myTogethersStatus = ELoadingStatus.init,
+        myTogethersMessage = null,
         myTogethers = const [],
+        //
         heartProductsStatus = ELoadingStatus.init,
+        heartProductsMessage = null,
         heartProducts = const [],
+        //
         heartTogethersStatus = ELoadingStatus.init,
+        heartTogethersMessage = null,
         heartTogethers = const [],
+        //
         purchaseProductsStatus = ELoadingStatus.init,
+        purchaseProductsMessage = null,
         purchaseProducts = const [],
+        //
         purchaseTogethersStatus = ELoadingStatus.init,
+        purchaseTogethersMessage = null,
         purchaseTogethers = const [],
         super(
           status: ELoadingStatus.init,
@@ -67,36 +101,63 @@ class ProfileTabState extends BlocState {
     ELoadingStatus? status,
     String? message,
     EChatItemType? category,
+    //
     ELoadingStatus? myProductsStatus,
+    String? myProductsMessage,
     List<ProductPreviewModel>? myProducts,
+    //
     ELoadingStatus? myTogethersStatus,
+    String? myTogethersMessage,
     List<TogetherPreviewModel>? myTogethers,
+    //
     ELoadingStatus? heartProductsStatus,
+    String? heartProductsMessage,
     List<ProductPreviewModel>? heartProducts,
+    //
     ELoadingStatus? heartTogethersStatus,
+    String? heartTogethersMessage,
     List<TogetherPreviewModel>? heartTogethers,
+    //
     ELoadingStatus? purchaseProductsStatus,
+    String? purchaseProductsMessage,
     List<PurchaseModel>? purchaseProducts,
+    //
     ELoadingStatus? purchaseTogethersStatus,
+    String? purchaseTogethersMessage,
     List<PurchaseModel>? purchaseTogethers,
   }) =>
       ProfileTabState(
         status: status ?? this.status,
         message: message ?? this.message,
         category: category ?? this.category,
+        //
         myProductsStatus: myProductsStatus ?? this.myProductsStatus,
+        myProductsMessage: myProductsMessage ?? this.myProductsMessage,
         myProducts: myProducts ?? this.myProducts,
+        //
         myTogethersStatus: myTogethersStatus ?? this.myTogethersStatus,
+        myTogethersMessage: myTogethersMessage ?? this.myTogethersMessage,
         myTogethers: myTogethers ?? this.myTogethers,
+        //
         heartProductsStatus: heartProductsStatus ?? this.heartProductsStatus,
+        heartProductsMessage: heartProductsMessage ?? this.heartProductsMessage,
         heartProducts: heartProducts ?? this.heartProducts,
+        //
         heartTogethersStatus: heartTogethersStatus ?? this.heartTogethersStatus,
+        heartTogethersMessage:
+            heartTogethersMessage ?? this.heartTogethersMessage,
         heartTogethers: heartTogethers ?? this.heartTogethers,
+        //
         purchaseProductsStatus:
             purchaseProductsStatus ?? this.purchaseProductsStatus,
+        purchaseProductsMessage:
+            purchaseProductsMessage ?? this.purchaseProductsMessage,
         purchaseProducts: purchaseProducts ?? this.purchaseProducts,
+        //
         purchaseTogethersStatus:
             purchaseTogethersStatus ?? this.purchaseTogethersStatus,
+        purchaseTogethersMessage:
+            purchaseTogethersMessage ?? this.purchaseTogethersMessage,
         purchaseTogethers: purchaseTogethers ?? this.purchaseTogethers,
       );
 
@@ -105,17 +166,29 @@ class ProfileTabState extends BlocState {
         status,
         message,
         category,
+        //
         myProductsStatus,
+        myProductsMessage,
         myProducts,
+        //
         myTogethersStatus,
+        myTogethersMessage,
         myTogethers,
+        //
         heartProductsStatus,
+        heartProductsMessage,
         heartProducts,
+        //
         heartTogethersStatus,
+        heartTogethersMessage,
         heartTogethers,
+        //
         purchaseProductsStatus,
+        purchaseProductsMessage,
         purchaseProducts,
+        //
         purchaseTogethersStatus,
+        purchaseTogethersMessage,
         purchaseTogethers,
       ];
 }

--- a/lib/blocs/profile/profile_tab_state.dart
+++ b/lib/blocs/profile/profile_tab_state.dart
@@ -6,22 +6,18 @@ import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
 import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
 
 class ProfileTabState extends BlocState {
-  final double outerScrollPos;
   final EChatItemType category;
 
-  final double myScrollPos;
   final ELoadingStatus myProductsStatus;
   final List<ProductPreviewModel> myProducts;
   final ELoadingStatus myTogethersStatus;
   final List<TogetherPreviewModel> myTogethers;
 
-  final double heartScrollPos;
   final ELoadingStatus heartProductsStatus;
   final List<ProductPreviewModel> heartProducts;
   final ELoadingStatus heartTogethersStatus;
   final List<TogetherPreviewModel> heartTogethers;
 
-  final double purchaseScrollPos;
   final ELoadingStatus purchaseProductsStatus;
   final List<PurchaseModel> purchaseProducts;
   final ELoadingStatus purchaseTogethersStatus;
@@ -30,19 +26,15 @@ class ProfileTabState extends BlocState {
   // TODO: review list
 
   const ProfileTabState({
-    required this.outerScrollPos,
     required this.category,
-    required this.myScrollPos,
     required this.myProductsStatus,
     required this.myProducts,
     required this.myTogethersStatus,
     required this.myTogethers,
-    required this.heartScrollPos,
     required this.heartProductsStatus,
     required this.heartProducts,
     required this.heartTogethersStatus,
     required this.heartTogethers,
-    required this.purchaseScrollPos,
     required this.purchaseProductsStatus,
     required this.purchaseProducts,
     required this.purchaseTogethersStatus,
@@ -52,19 +44,15 @@ class ProfileTabState extends BlocState {
   });
 
   const ProfileTabState.init()
-      : outerScrollPos = 0,
-        category = EChatItemType.product,
-        myScrollPos = 0,
+      : category = EChatItemType.product,
         myProductsStatus = ELoadingStatus.init,
         myProducts = const [],
         myTogethersStatus = ELoadingStatus.init,
         myTogethers = const [],
-        heartScrollPos = 0,
         heartProductsStatus = ELoadingStatus.init,
         heartProducts = const [],
         heartTogethersStatus = ELoadingStatus.init,
         heartTogethers = const [],
-        purchaseScrollPos = 0,
         purchaseProductsStatus = ELoadingStatus.init,
         purchaseProducts = const [],
         purchaseTogethersStatus = ELoadingStatus.init,
@@ -78,19 +66,15 @@ class ProfileTabState extends BlocState {
   ProfileTabState copyWith({
     ELoadingStatus? status,
     String? message,
-    double? outerScrollPos,
     EChatItemType? category,
-    double? myScrollPos,
     ELoadingStatus? myProductsStatus,
     List<ProductPreviewModel>? myProducts,
     ELoadingStatus? myTogethersStatus,
     List<TogetherPreviewModel>? myTogethers,
-    double? heartScrollPos,
     ELoadingStatus? heartProductsStatus,
     List<ProductPreviewModel>? heartProducts,
     ELoadingStatus? heartTogethersStatus,
     List<TogetherPreviewModel>? heartTogethers,
-    double? purchaseScrollPos,
     ELoadingStatus? purchaseProductsStatus,
     List<PurchaseModel>? purchaseProducts,
     ELoadingStatus? purchaseTogethersStatus,
@@ -99,19 +83,15 @@ class ProfileTabState extends BlocState {
       ProfileTabState(
         status: status ?? this.status,
         message: message ?? this.message,
-        outerScrollPos: outerScrollPos ?? this.outerScrollPos,
         category: category ?? this.category,
-        myScrollPos: myScrollPos ?? this.myScrollPos,
         myProductsStatus: myProductsStatus ?? this.myProductsStatus,
         myProducts: myProducts ?? this.myProducts,
         myTogethersStatus: myTogethersStatus ?? this.myTogethersStatus,
         myTogethers: myTogethers ?? this.myTogethers,
-        heartScrollPos: heartScrollPos ?? this.heartScrollPos,
         heartProductsStatus: heartProductsStatus ?? this.heartProductsStatus,
         heartProducts: heartProducts ?? this.heartProducts,
         heartTogethersStatus: heartTogethersStatus ?? this.heartTogethersStatus,
         heartTogethers: heartTogethers ?? this.heartTogethers,
-        purchaseScrollPos: purchaseScrollPos ?? this.purchaseScrollPos,
         purchaseProductsStatus:
             purchaseProductsStatus ?? this.purchaseProductsStatus,
         purchaseProducts: purchaseProducts ?? this.purchaseProducts,
@@ -124,19 +104,15 @@ class ProfileTabState extends BlocState {
   List<Object?> get props => [
         status,
         message,
-        outerScrollPos,
         category,
-        myScrollPos,
         myProductsStatus,
         myProducts,
         myTogethersStatus,
         myTogethers,
-        heartScrollPos,
         heartProductsStatus,
         heartProducts,
         heartTogethersStatus,
         heartTogethers,
-        purchaseScrollPos,
         purchaseProductsStatus,
         purchaseProducts,
         purchaseTogethersStatus,

--- a/lib/blocs/profile/profile_tab_state.dart
+++ b/lib/blocs/profile/profile_tab_state.dart
@@ -1,0 +1,145 @@
+import 'package:child_goods_store_flutter/blocs/abs_bloc_state.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/enums/loading_status.dart';
+import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
+import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
+import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+
+class ProfileTabState extends BlocState {
+  final double outerScrollPos;
+  final EChatItemType category;
+
+  final double myScrollPos;
+  final ELoadingStatus myProductsStatus;
+  final List<ProductPreviewModel> myProducts;
+  final ELoadingStatus myTogethersStatus;
+  final List<TogetherPreviewModel> myTogethers;
+
+  final double heartScrollPos;
+  final ELoadingStatus heartProductsStatus;
+  final List<ProductPreviewModel> heartProducts;
+  final ELoadingStatus heartTogethersStatus;
+  final List<TogetherPreviewModel> heartTogethers;
+
+  final double purchaseScrollPos;
+  final ELoadingStatus purchaseProductsStatus;
+  final List<PurchaseModel> purchaseProducts;
+  final ELoadingStatus purchaseTogethersStatus;
+  final List<PurchaseModel> purchaseTogethers;
+
+  // TODO: review list
+
+  const ProfileTabState({
+    required this.outerScrollPos,
+    required this.category,
+    required this.myScrollPos,
+    required this.myProductsStatus,
+    required this.myProducts,
+    required this.myTogethersStatus,
+    required this.myTogethers,
+    required this.heartScrollPos,
+    required this.heartProductsStatus,
+    required this.heartProducts,
+    required this.heartTogethersStatus,
+    required this.heartTogethers,
+    required this.purchaseScrollPos,
+    required this.purchaseProductsStatus,
+    required this.purchaseProducts,
+    required this.purchaseTogethersStatus,
+    required this.purchaseTogethers,
+    required super.status,
+    super.message,
+  });
+
+  const ProfileTabState.init()
+      : outerScrollPos = 0,
+        category = EChatItemType.product,
+        myScrollPos = 0,
+        myProductsStatus = ELoadingStatus.init,
+        myProducts = const [],
+        myTogethersStatus = ELoadingStatus.init,
+        myTogethers = const [],
+        heartScrollPos = 0,
+        heartProductsStatus = ELoadingStatus.init,
+        heartProducts = const [],
+        heartTogethersStatus = ELoadingStatus.init,
+        heartTogethers = const [],
+        purchaseScrollPos = 0,
+        purchaseProductsStatus = ELoadingStatus.init,
+        purchaseProducts = const [],
+        purchaseTogethersStatus = ELoadingStatus.init,
+        purchaseTogethers = const [],
+        super(
+          status: ELoadingStatus.init,
+          message: null,
+        );
+
+  @override
+  ProfileTabState copyWith({
+    ELoadingStatus? status,
+    String? message,
+    double? outerScrollPos,
+    EChatItemType? category,
+    double? myScrollPos,
+    ELoadingStatus? myProductsStatus,
+    List<ProductPreviewModel>? myProducts,
+    ELoadingStatus? myTogethersStatus,
+    List<TogetherPreviewModel>? myTogethers,
+    double? heartScrollPos,
+    ELoadingStatus? heartProductsStatus,
+    List<ProductPreviewModel>? heartProducts,
+    ELoadingStatus? heartTogethersStatus,
+    List<TogetherPreviewModel>? heartTogethers,
+    double? purchaseScrollPos,
+    ELoadingStatus? purchaseProductsStatus,
+    List<PurchaseModel>? purchaseProducts,
+    ELoadingStatus? purchaseTogethersStatus,
+    List<PurchaseModel>? purchaseTogethers,
+  }) =>
+      ProfileTabState(
+        status: status ?? this.status,
+        message: message ?? this.message,
+        outerScrollPos: outerScrollPos ?? this.outerScrollPos,
+        category: category ?? this.category,
+        myScrollPos: myScrollPos ?? this.myScrollPos,
+        myProductsStatus: myProductsStatus ?? this.myProductsStatus,
+        myProducts: myProducts ?? this.myProducts,
+        myTogethersStatus: myTogethersStatus ?? this.myTogethersStatus,
+        myTogethers: myTogethers ?? this.myTogethers,
+        heartScrollPos: heartScrollPos ?? this.heartScrollPos,
+        heartProductsStatus: heartProductsStatus ?? this.heartProductsStatus,
+        heartProducts: heartProducts ?? this.heartProducts,
+        heartTogethersStatus: heartTogethersStatus ?? this.heartTogethersStatus,
+        heartTogethers: heartTogethers ?? this.heartTogethers,
+        purchaseScrollPos: purchaseScrollPos ?? this.purchaseScrollPos,
+        purchaseProductsStatus:
+            purchaseProductsStatus ?? this.purchaseProductsStatus,
+        purchaseProducts: purchaseProducts ?? this.purchaseProducts,
+        purchaseTogethersStatus:
+            purchaseTogethersStatus ?? this.purchaseTogethersStatus,
+        purchaseTogethers: purchaseTogethers ?? this.purchaseTogethers,
+      );
+
+  @override
+  List<Object?> get props => [
+        status,
+        message,
+        outerScrollPos,
+        category,
+        myScrollPos,
+        myProductsStatus,
+        myProducts,
+        myTogethersStatus,
+        myTogethers,
+        heartScrollPos,
+        heartProductsStatus,
+        heartProducts,
+        heartTogethersStatus,
+        heartTogethers,
+        purchaseScrollPos,
+        purchaseProductsStatus,
+        purchaseProducts,
+        purchaseTogethersStatus,
+        purchaseTogethers,
+      ];
+}

--- a/lib/enums/chat_item_type.dart
+++ b/lib/enums/chat_item_type.dart
@@ -1,0 +1,55 @@
+enum EChatItemType {
+  product('중고거래'),
+  together('공동구매');
+
+  final String text;
+
+  const EChatItemType(this.text);
+
+  static String? toJson(EChatItemType? en) {
+    switch (en) {
+      case EChatItemType.product:
+        return 'PRODUCT';
+      case EChatItemType.together:
+        return 'TOGETHER';
+      default:
+        return null;
+    }
+  }
+
+  static EChatItemType? fromJson(String? str) {
+    switch (str?.toUpperCase()) {
+      case 'PRODUCT':
+        return EChatItemType.product;
+      case 'TOGETHER':
+        return EChatItemType.together;
+      default:
+        return null;
+    }
+  }
+}
+
+extension SChatItemTypeExtension on String {
+  EChatItemType get chatItemTypeEnum {
+    switch (this) {
+      case '중고거래':
+        return EChatItemType.product;
+      case '공동구매':
+        return EChatItemType.together;
+      default:
+        throw Exception(
+            '[SChatItemTypeExtension.enumVal] Unknown string value: $this');
+    }
+  }
+}
+
+extension EChatItemTypeExtension on EChatItemType {
+  String get key {
+    switch (this) {
+      case EChatItemType.product:
+        return 'PRODUCT';
+      case EChatItemType.together:
+        return 'TOGETHER';
+    }
+  }
+}

--- a/lib/models/purchase/purchase_model.dart
+++ b/lib/models/purchase/purchase_model.dart
@@ -17,6 +17,7 @@ class PurchaseModel with _$PurchaseModel {
     String? sellerName,
     int? price,
     DateTime? saleCompleteDate,
+    String? image,
     bool? isReview,
   }) = _PurchaseModel;
 

--- a/lib/models/purchase/purchase_model.dart
+++ b/lib/models/purchase/purchase_model.dart
@@ -1,0 +1,25 @@
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'purchase_model.freezed.dart';
+part 'purchase_model.g.dart';
+
+@freezed
+class PurchaseModel with _$PurchaseModel {
+  factory PurchaseModel({
+    @JsonKey(
+      fromJson: EChatItemType.fromJson,
+      toJson: EChatItemType.toJson,
+    )
+    EChatItemType? category,
+    int? id,
+    String? name,
+    String? sellerName,
+    int? price,
+    DateTime? saleCompleteDate,
+    bool? isReview,
+  }) = _PurchaseModel;
+
+  factory PurchaseModel.fromJson(Map<String, dynamic> json) =>
+      _$PurchaseModelFromJson(json);
+}

--- a/lib/models/purchase/purchase_model.freezed.dart
+++ b/lib/models/purchase/purchase_model.freezed.dart
@@ -1,0 +1,287 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'purchase_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PurchaseModel _$PurchaseModelFromJson(Map<String, dynamic> json) {
+  return _PurchaseModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PurchaseModel {
+  @JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+  EChatItemType? get category => throw _privateConstructorUsedError;
+  int? get id => throw _privateConstructorUsedError;
+  String? get name => throw _privateConstructorUsedError;
+  String? get sellerName => throw _privateConstructorUsedError;
+  int? get price => throw _privateConstructorUsedError;
+  DateTime? get saleCompleteDate => throw _privateConstructorUsedError;
+  bool? get isReview => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PurchaseModelCopyWith<PurchaseModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PurchaseModelCopyWith<$Res> {
+  factory $PurchaseModelCopyWith(
+          PurchaseModel value, $Res Function(PurchaseModel) then) =
+      _$PurchaseModelCopyWithImpl<$Res, PurchaseModel>;
+  @useResult
+  $Res call(
+      {@JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+      EChatItemType? category,
+      int? id,
+      String? name,
+      String? sellerName,
+      int? price,
+      DateTime? saleCompleteDate,
+      bool? isReview});
+}
+
+/// @nodoc
+class _$PurchaseModelCopyWithImpl<$Res, $Val extends PurchaseModel>
+    implements $PurchaseModelCopyWith<$Res> {
+  _$PurchaseModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? category = freezed,
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? sellerName = freezed,
+    Object? price = freezed,
+    Object? saleCompleteDate = freezed,
+    Object? isReview = freezed,
+  }) {
+    return _then(_value.copyWith(
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as EChatItemType?,
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sellerName: freezed == sellerName
+          ? _value.sellerName
+          : sellerName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      price: freezed == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int?,
+      saleCompleteDate: freezed == saleCompleteDate
+          ? _value.saleCompleteDate
+          : saleCompleteDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      isReview: freezed == isReview
+          ? _value.isReview
+          : isReview // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PurchaseModelImplCopyWith<$Res>
+    implements $PurchaseModelCopyWith<$Res> {
+  factory _$$PurchaseModelImplCopyWith(
+          _$PurchaseModelImpl value, $Res Function(_$PurchaseModelImpl) then) =
+      __$$PurchaseModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+      EChatItemType? category,
+      int? id,
+      String? name,
+      String? sellerName,
+      int? price,
+      DateTime? saleCompleteDate,
+      bool? isReview});
+}
+
+/// @nodoc
+class __$$PurchaseModelImplCopyWithImpl<$Res>
+    extends _$PurchaseModelCopyWithImpl<$Res, _$PurchaseModelImpl>
+    implements _$$PurchaseModelImplCopyWith<$Res> {
+  __$$PurchaseModelImplCopyWithImpl(
+      _$PurchaseModelImpl _value, $Res Function(_$PurchaseModelImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? category = freezed,
+    Object? id = freezed,
+    Object? name = freezed,
+    Object? sellerName = freezed,
+    Object? price = freezed,
+    Object? saleCompleteDate = freezed,
+    Object? isReview = freezed,
+  }) {
+    return _then(_$PurchaseModelImpl(
+      category: freezed == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
+              as EChatItemType?,
+      id: freezed == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sellerName: freezed == sellerName
+          ? _value.sellerName
+          : sellerName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      price: freezed == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int?,
+      saleCompleteDate: freezed == saleCompleteDate
+          ? _value.saleCompleteDate
+          : saleCompleteDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      isReview: freezed == isReview
+          ? _value.isReview
+          : isReview // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PurchaseModelImpl implements _PurchaseModel {
+  _$PurchaseModelImpl(
+      {@JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+      this.category,
+      this.id,
+      this.name,
+      this.sellerName,
+      this.price,
+      this.saleCompleteDate,
+      this.isReview});
+
+  factory _$PurchaseModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurchaseModelImplFromJson(json);
+
+  @override
+  @JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+  final EChatItemType? category;
+  @override
+  final int? id;
+  @override
+  final String? name;
+  @override
+  final String? sellerName;
+  @override
+  final int? price;
+  @override
+  final DateTime? saleCompleteDate;
+  @override
+  final bool? isReview;
+
+  @override
+  String toString() {
+    return 'PurchaseModel(category: $category, id: $id, name: $name, sellerName: $sellerName, price: $price, saleCompleteDate: $saleCompleteDate, isReview: $isReview)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PurchaseModelImpl &&
+            (identical(other.category, category) ||
+                other.category == category) &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.sellerName, sellerName) ||
+                other.sellerName == sellerName) &&
+            (identical(other.price, price) || other.price == price) &&
+            (identical(other.saleCompleteDate, saleCompleteDate) ||
+                other.saleCompleteDate == saleCompleteDate) &&
+            (identical(other.isReview, isReview) ||
+                other.isReview == isReview));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, category, id, name, sellerName,
+      price, saleCompleteDate, isReview);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PurchaseModelImplCopyWith<_$PurchaseModelImpl> get copyWith =>
+      __$$PurchaseModelImplCopyWithImpl<_$PurchaseModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PurchaseModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PurchaseModel implements PurchaseModel {
+  factory _PurchaseModel(
+      {@JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+      final EChatItemType? category,
+      final int? id,
+      final String? name,
+      final String? sellerName,
+      final int? price,
+      final DateTime? saleCompleteDate,
+      final bool? isReview}) = _$PurchaseModelImpl;
+
+  factory _PurchaseModel.fromJson(Map<String, dynamic> json) =
+      _$PurchaseModelImpl.fromJson;
+
+  @override
+  @JsonKey(fromJson: EChatItemType.fromJson, toJson: EChatItemType.toJson)
+  EChatItemType? get category;
+  @override
+  int? get id;
+  @override
+  String? get name;
+  @override
+  String? get sellerName;
+  @override
+  int? get price;
+  @override
+  DateTime? get saleCompleteDate;
+  @override
+  bool? get isReview;
+  @override
+  @JsonKey(ignore: true)
+  _$$PurchaseModelImplCopyWith<_$PurchaseModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/purchase/purchase_model.freezed.dart
+++ b/lib/models/purchase/purchase_model.freezed.dart
@@ -27,6 +27,7 @@ mixin _$PurchaseModel {
   String? get sellerName => throw _privateConstructorUsedError;
   int? get price => throw _privateConstructorUsedError;
   DateTime? get saleCompleteDate => throw _privateConstructorUsedError;
+  String? get image => throw _privateConstructorUsedError;
   bool? get isReview => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -49,6 +50,7 @@ abstract class $PurchaseModelCopyWith<$Res> {
       String? sellerName,
       int? price,
       DateTime? saleCompleteDate,
+      String? image,
       bool? isReview});
 }
 
@@ -71,6 +73,7 @@ class _$PurchaseModelCopyWithImpl<$Res, $Val extends PurchaseModel>
     Object? sellerName = freezed,
     Object? price = freezed,
     Object? saleCompleteDate = freezed,
+    Object? image = freezed,
     Object? isReview = freezed,
   }) {
     return _then(_value.copyWith(
@@ -98,6 +101,10 @@ class _$PurchaseModelCopyWithImpl<$Res, $Val extends PurchaseModel>
           ? _value.saleCompleteDate
           : saleCompleteDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
       isReview: freezed == isReview
           ? _value.isReview
           : isReview // ignore: cast_nullable_to_non_nullable
@@ -122,6 +129,7 @@ abstract class _$$PurchaseModelImplCopyWith<$Res>
       String? sellerName,
       int? price,
       DateTime? saleCompleteDate,
+      String? image,
       bool? isReview});
 }
 
@@ -142,6 +150,7 @@ class __$$PurchaseModelImplCopyWithImpl<$Res>
     Object? sellerName = freezed,
     Object? price = freezed,
     Object? saleCompleteDate = freezed,
+    Object? image = freezed,
     Object? isReview = freezed,
   }) {
     return _then(_$PurchaseModelImpl(
@@ -169,6 +178,10 @@ class __$$PurchaseModelImplCopyWithImpl<$Res>
           ? _value.saleCompleteDate
           : saleCompleteDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
       isReview: freezed == isReview
           ? _value.isReview
           : isReview // ignore: cast_nullable_to_non_nullable
@@ -188,6 +201,7 @@ class _$PurchaseModelImpl implements _PurchaseModel {
       this.sellerName,
       this.price,
       this.saleCompleteDate,
+      this.image,
       this.isReview});
 
   factory _$PurchaseModelImpl.fromJson(Map<String, dynamic> json) =>
@@ -207,11 +221,13 @@ class _$PurchaseModelImpl implements _PurchaseModel {
   @override
   final DateTime? saleCompleteDate;
   @override
+  final String? image;
+  @override
   final bool? isReview;
 
   @override
   String toString() {
-    return 'PurchaseModel(category: $category, id: $id, name: $name, sellerName: $sellerName, price: $price, saleCompleteDate: $saleCompleteDate, isReview: $isReview)';
+    return 'PurchaseModel(category: $category, id: $id, name: $name, sellerName: $sellerName, price: $price, saleCompleteDate: $saleCompleteDate, image: $image, isReview: $isReview)';
   }
 
   @override
@@ -228,6 +244,7 @@ class _$PurchaseModelImpl implements _PurchaseModel {
             (identical(other.price, price) || other.price == price) &&
             (identical(other.saleCompleteDate, saleCompleteDate) ||
                 other.saleCompleteDate == saleCompleteDate) &&
+            (identical(other.image, image) || other.image == image) &&
             (identical(other.isReview, isReview) ||
                 other.isReview == isReview));
   }
@@ -235,7 +252,7 @@ class _$PurchaseModelImpl implements _PurchaseModel {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(runtimeType, category, id, name, sellerName,
-      price, saleCompleteDate, isReview);
+      price, saleCompleteDate, image, isReview);
 
   @JsonKey(ignore: true)
   @override
@@ -260,6 +277,7 @@ abstract class _PurchaseModel implements PurchaseModel {
       final String? sellerName,
       final int? price,
       final DateTime? saleCompleteDate,
+      final String? image,
       final bool? isReview}) = _$PurchaseModelImpl;
 
   factory _PurchaseModel.fromJson(Map<String, dynamic> json) =
@@ -278,6 +296,8 @@ abstract class _PurchaseModel implements PurchaseModel {
   int? get price;
   @override
   DateTime? get saleCompleteDate;
+  @override
+  String? get image;
   @override
   bool? get isReview;
   @override

--- a/lib/models/purchase/purchase_model.g.dart
+++ b/lib/models/purchase/purchase_model.g.dart
@@ -16,6 +16,7 @@ _$PurchaseModelImpl _$$PurchaseModelImplFromJson(Map<String, dynamic> json) =>
       saleCompleteDate: json['saleCompleteDate'] == null
           ? null
           : DateTime.parse(json['saleCompleteDate'] as String),
+      image: json['image'] as String?,
       isReview: json['isReview'] as bool?,
     );
 
@@ -27,5 +28,6 @@ Map<String, dynamic> _$$PurchaseModelImplToJson(_$PurchaseModelImpl instance) =>
       'sellerName': instance.sellerName,
       'price': instance.price,
       'saleCompleteDate': instance.saleCompleteDate?.toIso8601String(),
+      'image': instance.image,
       'isReview': instance.isReview,
     };

--- a/lib/models/purchase/purchase_model.g.dart
+++ b/lib/models/purchase/purchase_model.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'purchase_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PurchaseModelImpl _$$PurchaseModelImplFromJson(Map<String, dynamic> json) =>
+    _$PurchaseModelImpl(
+      category: EChatItemType.fromJson(json['category'] as String?),
+      id: json['id'] as int?,
+      name: json['name'] as String?,
+      sellerName: json['sellerName'] as String?,
+      price: json['price'] as int?,
+      saleCompleteDate: json['saleCompleteDate'] == null
+          ? null
+          : DateTime.parse(json['saleCompleteDate'] as String),
+      isReview: json['isReview'] as bool?,
+    );
+
+Map<String, dynamic> _$$PurchaseModelImplToJson(_$PurchaseModelImpl instance) =>
+    <String, dynamic>{
+      'category': EChatItemType.toJson(instance.category),
+      'id': instance.id,
+      'name': instance.name,
+      'sellerName': instance.sellerName,
+      'price': instance.price,
+      'saleCompleteDate': instance.saleCompleteDate?.toIso8601String(),
+      'isReview': instance.isReview,
+    };

--- a/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
+++ b/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
@@ -1,5 +1,6 @@
 import 'package:child_goods_store_flutter/blocs/auth/auth_bloc_singleton.dart';
 import 'package:child_goods_store_flutter/blocs/product/buyer/product_buyer_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/product/buyer/product_buyer_event.dart';
 import 'package:child_goods_store_flutter/blocs/product/detail/product_detail_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/product/detail/product_detail_event.dart';
 import 'package:child_goods_store_flutter/blocs/product/detail/product_detail_state.dart';
@@ -79,6 +80,7 @@ class _ProductDetailBottomBarState extends State<ProductDetailBottomBar> {
       context.pop();
     } else {
       context.pop();
+      bloc.add(ProductBuyerGet());
       AppBottomSheet.showList(
         context,
         builder: (_, controller) => ProductDetailBuyerList(

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -11,6 +11,8 @@ import 'package:child_goods_store_flutter/enums/loading_status.dart';
 import 'package:child_goods_store_flutter/pages/profile/widgets/profile_card.dart';
 import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_heart.dart';
 import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_myitem.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_purchase.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_review.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
 import 'package:child_goods_store_flutter/widgets/app_snackbar.dart';
@@ -188,11 +190,11 @@ class _ProfilePageState extends State<ProfilePage>
               nestedScrollKey: _nestedScrollKey,
             ),
           if (!widget.popAble)
-            const Center(
-              child: AppFont('tab3'),
+            ProfileTabPurchase(
+              nestedScrollKey: _nestedScrollKey,
             ),
-          const Center(
-            child: AppFont('tab4'),
+          ProfileTabReview(
+            nestedScrollKey: _nestedScrollKey,
           ),
         ],
       ),

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -5,16 +5,20 @@ import 'package:child_goods_store_flutter/blocs/profile/profile_bloc.dart';
 import 'package:child_goods_store_flutter/blocs/profile/profile_event.dart';
 import 'package:child_goods_store_flutter/blocs/profile/profile_state.dart';
 import 'package:child_goods_store_flutter/constants/gaps.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
 import 'package:child_goods_store_flutter/constants/strings.dart';
 import 'package:child_goods_store_flutter/enums/loading_status.dart';
 import 'package:child_goods_store_flutter/pages/profile/widgets/profile_card.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_heart.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_myitem.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
 import 'package:child_goods_store_flutter/widgets/app_snackbar.dart';
+import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class ProfilePage extends StatelessWidget {
+class ProfilePage extends StatefulWidget {
   final bool popAble;
 
   const ProfilePage({
@@ -22,8 +26,43 @@ class ProfilePage extends StatelessWidget {
     required this.popAble,
   });
 
-  void _onTapRetryGetProfile(BuildContext context) {
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  late final GlobalKey<ExtendedNestedScrollViewState> _nestedScrollKey =
+      GlobalKey<ExtendedNestedScrollViewState>();
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: widget.popAble ? 2 : 4,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _onTapRetryGetProfile() {
     context.read<ProfileBloc>().add(ProfileGet());
+  }
+
+  void _onTapTab(int index) {
+    if (!_tabController.indexIsChanging) {
+      _nestedScrollKey.currentState?.innerController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 500),
+        curve: Curves.easeOut,
+      );
+    }
   }
 
   @override
@@ -51,7 +90,7 @@ class ProfilePage extends StatelessWidget {
         )
       ],
       child: Scaffold(
-        appBar: popAble
+        appBar: widget.popAble
             ? AppBar(
                 title: const AppFont('프로필'),
               )
@@ -83,15 +122,80 @@ class ProfilePage extends StatelessWidget {
     BuildContext context, {
     required ProfileState state,
   }) {
-    return CustomScrollView(
-      slivers: [
+    return ExtendedNestedScrollView(
+      key: _nestedScrollKey,
+      physics: const BouncingScrollPhysics(),
+      onlyOneScrollInBody: true,
+      pinnedHeaderSliverHeightBuilder: () => Sizes.size52,
+      headerSliverBuilder: (context, innerBoxIsScrolled) => [
         SliverToBoxAdapter(
           child: ProfileCard(
             userProfile: state.userProfile!,
-            popAble: popAble,
+            popAble: widget.popAble,
+          ),
+        ),
+        SliverAppBar(
+          pinned: true,
+          automaticallyImplyLeading: false,
+          titleSpacing: 0,
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          toolbarHeight: Sizes.size52,
+          title: SizedBox(
+            height: Sizes.size52,
+            child: TabBar(
+              controller: _tabController,
+              onTap: _onTapTab,
+              tabAlignment: TabAlignment.start,
+              isScrollable: true,
+              padding: const EdgeInsets.symmetric(
+                horizontal: Sizes.size20,
+              ),
+              labelPadding: const EdgeInsets.symmetric(
+                horizontal: Sizes.size20,
+              ),
+              tabs: [
+                const Tab(
+                  text: '게시한 글',
+                  height: Sizes.size52,
+                ),
+                if (!widget.popAble)
+                  const Tab(
+                    text: '관심 목록',
+                    height: Sizes.size52,
+                  ),
+                if (!widget.popAble)
+                  const Tab(
+                    text: '구매 내역',
+                    height: Sizes.size52,
+                  ),
+                const Tab(
+                  text: '받은 후기',
+                  height: Sizes.size52,
+                ),
+              ],
+            ),
           ),
         ),
       ],
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          ProfileTabMyItem(
+            nestedScrollKey: _nestedScrollKey,
+          ),
+          if (!widget.popAble)
+            ProfileTabHeart(
+              nestedScrollKey: _nestedScrollKey,
+            ),
+          if (!widget.popAble)
+            const Center(
+              child: AppFont('tab3'),
+            ),
+          const Center(
+            child: AppFont('tab4'),
+          ),
+        ],
+      ),
     );
   }
 
@@ -106,7 +210,7 @@ class ProfilePage extends StatelessWidget {
           AppFont(message),
           Gaps.v20,
           AppInkButton(
-            onTap: () => _onTapRetryGetProfile(context),
+            onTap: _onTapRetryGetProfile,
             child: const AppFont(
               '재시도',
               color: Colors.white,

--- a/lib/pages/profile/widgets/profile_tab_category_dropdown.dart
+++ b/lib/pages/profile/widgets/profile_tab_category_dropdown.dart
@@ -1,0 +1,43 @@
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_event.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_state.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/widgets/app_dropdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProfileTabCategoryDropdown extends StatelessWidget {
+  const ProfileTabCategoryDropdown({super.key});
+
+  void _onChangeCategory(
+    BuildContext context, {
+    String? category,
+  }) {
+    if (category == null) return;
+    context.read<ProfileTabBloc>().add(ProfileTabChangeCategory(
+          category.chatItemTypeEnum,
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileTabBloc, ProfileTabState>(
+      builder: (context, state) => SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.all(Sizes.size20),
+          child: AppDropdown(
+            width: double.infinity,
+            hint: '카테고리',
+            value: state.category.text,
+            values: EChatItemType.values.map((cat) => cat.text).toList(),
+            onChanged: (value) => _onChangeCategory(
+              context,
+              category: value,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/profile/widgets/profile_tab_heart.dart
+++ b/lib/pages/profile/widgets/profile_tab_heart.dart
@@ -1,0 +1,163 @@
+// ignore_for_file: missing_override_of_must_be_overridden
+
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_event.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_state.dart';
+import 'package:child_goods_store_flutter/constants/gaps.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/constants/strings.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/enums/loading_status.dart';
+import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
+import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_category_dropdown.dart';
+import 'package:child_goods_store_flutter/widgets/app_font.dart';
+import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
+import 'package:child_goods_store_flutter/widgets/common/product_listitem.dart';
+import 'package:child_goods_store_flutter/widgets/common/together_listitem.dart';
+import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProfileTabHeart extends StatefulWidget {
+  final GlobalKey<ExtendedNestedScrollViewState> nestedScrollKey;
+
+  const ProfileTabHeart({
+    super.key,
+    required this.nestedScrollKey,
+  });
+
+  @override
+  State<ProfileTabHeart> createState() => _ProfileTabHeartState();
+}
+
+class _ProfileTabHeartState extends State<ProfileTabHeart>
+    with AutomaticKeepAliveClientMixin<ProfileTabHeart> {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _initLoadData();
+  }
+
+  void _initLoadData() {
+    var bloc = context.read<ProfileTabBloc>();
+    if (bloc.state.heartProductsStatus == ELoadingStatus.init &&
+        bloc.state.category == EChatItemType.product) {
+      _loadData();
+    }
+    if (bloc.state.heartTogethersStatus == ELoadingStatus.init &&
+        bloc.state.category == EChatItemType.together) {
+      _loadData();
+    }
+  }
+
+  void _loadData() {
+    var bloc = context.read<ProfileTabBloc>();
+    if (bloc.state.category == EChatItemType.product) {
+      bloc.add(ProfileTabGetHeartProducts());
+    } else {
+      bloc.add(ProfileTabGetHeartTogethers());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification.metrics.pixels >=
+            notification.metrics.maxScrollExtent) {
+          _loadData();
+        }
+        return false;
+      },
+      child: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          const ProfileTabCategoryDropdown(),
+          BlocConsumer<ProfileTabBloc, ProfileTabState>(
+            listenWhen: (previous, current) =>
+                previous.category != current.category,
+            listener: (context, state) {
+              _initLoadData();
+            },
+            builder: (context, state) {
+              if (state.category == EChatItemType.product) {
+                return _productList(state.heartProducts);
+              }
+              return _togetherList(state.heartTogethers);
+            },
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: Sizes.size20),
+              child: Center(
+                child: BlocBuilder<ProfileTabBloc, ProfileTabState>(
+                  builder: (context, state) {
+                    if (state.status == ELoadingStatus.error &&
+                        state.heartProductsStatus == ELoadingStatus.loading) {
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          AppFont(state.message ?? Strings.unknownFail),
+                          Gaps.v20,
+                          AppInkButton(
+                            onTap: _loadData,
+                            child: const AppFont(
+                              '재시도',
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+                    return const CircularProgressIndicator();
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _productList(List<ProductPreviewModel> products) {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Sizes.size20,
+      ),
+      sliver: SliverGrid.builder(
+        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: 300,
+          childAspectRatio: 2 / 3,
+          crossAxisSpacing: Sizes.size16,
+          mainAxisSpacing: Sizes.size16,
+        ),
+        itemBuilder: (context, index) => ProductListItem(
+          product: products[index],
+        ),
+        itemCount: products.length,
+      ),
+    );
+  }
+
+  Widget _togetherList(List<TogetherPreviewModel> togethers) {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Sizes.size20,
+        vertical: Sizes.size10,
+      ),
+      sliver: SliverList.separated(
+        itemBuilder: (context, index) => TogetherListItem(
+          together: togethers[index],
+        ),
+        separatorBuilder: (context, index) => Gaps.v16,
+        itemCount: togethers.length,
+      ),
+    );
+  }
+}

--- a/lib/pages/profile/widgets/profile_tab_myitem.dart
+++ b/lib/pages/profile/widgets/profile_tab_myitem.dart
@@ -1,0 +1,161 @@
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_event.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_state.dart';
+import 'package:child_goods_store_flutter/constants/gaps.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/constants/strings.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/enums/loading_status.dart';
+import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
+import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_category_dropdown.dart';
+import 'package:child_goods_store_flutter/widgets/app_font.dart';
+import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
+import 'package:child_goods_store_flutter/widgets/common/product_listitem.dart';
+import 'package:child_goods_store_flutter/widgets/common/together_listitem.dart';
+import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProfileTabMyItem extends StatefulWidget {
+  final GlobalKey<ExtendedNestedScrollViewState> nestedScrollKey;
+
+  const ProfileTabMyItem({
+    super.key,
+    required this.nestedScrollKey,
+  });
+
+  @override
+  State<ProfileTabMyItem> createState() => _ProfileTabMyItemState();
+}
+
+class _ProfileTabMyItemState extends State<ProfileTabMyItem>
+    with AutomaticKeepAliveClientMixin<ProfileTabMyItem> {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _initLoadData();
+  }
+
+  void _initLoadData() {
+    var bloc = context.read<ProfileTabBloc>();
+    if (bloc.state.myProductsStatus == ELoadingStatus.init &&
+        bloc.state.category == EChatItemType.product) {
+      _loadData();
+    }
+    if (bloc.state.myTogethersStatus == ELoadingStatus.init &&
+        bloc.state.category == EChatItemType.together) {
+      _loadData();
+    }
+  }
+
+  void _loadData() {
+    var bloc = context.read<ProfileTabBloc>();
+    if (bloc.state.category == EChatItemType.product) {
+      bloc.add(ProfileTabGetProducts());
+    } else {
+      bloc.add(ProfileTabGetTogethers());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification.metrics.pixels >=
+            notification.metrics.maxScrollExtent) {
+          _loadData();
+        }
+        return false;
+      },
+      child: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          const ProfileTabCategoryDropdown(),
+          BlocConsumer<ProfileTabBloc, ProfileTabState>(
+            listenWhen: (previous, current) =>
+                previous.category != current.category,
+            listener: (context, state) {
+              _initLoadData();
+            },
+            builder: (context, state) {
+              if (state.category == EChatItemType.product) {
+                return _productList(state.myProducts);
+              }
+              return _togetherList(state.myTogethers);
+            },
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: Sizes.size20),
+              child: Center(
+                child: BlocBuilder<ProfileTabBloc, ProfileTabState>(
+                  builder: (context, state) {
+                    if (state.status == ELoadingStatus.error &&
+                        state.myProductsStatus == ELoadingStatus.loading) {
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          AppFont(state.message ?? Strings.unknownFail),
+                          Gaps.v20,
+                          AppInkButton(
+                            onTap: _loadData,
+                            child: const AppFont(
+                              '재시도',
+                              color: Colors.white,
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+                    return const CircularProgressIndicator();
+                  },
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _productList(List<ProductPreviewModel> products) {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Sizes.size20,
+      ),
+      sliver: SliverGrid.builder(
+        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: 300,
+          childAspectRatio: 2 / 3,
+          crossAxisSpacing: Sizes.size16,
+          mainAxisSpacing: Sizes.size16,
+        ),
+        itemBuilder: (context, index) => ProductListItem(
+          product: products[index],
+        ),
+        itemCount: products.length,
+      ),
+    );
+  }
+
+  Widget _togetherList(List<TogetherPreviewModel> togethers) {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Sizes.size20,
+        vertical: Sizes.size10,
+      ),
+      sliver: SliverList.separated(
+        itemBuilder: (context, index) => TogetherListItem(
+          together: togethers[index],
+        ),
+        separatorBuilder: (context, index) => Gaps.v16,
+        itemCount: togethers.length,
+      ),
+    );
+  }
+}

--- a/lib/pages/profile/widgets/profile_tab_purchase.dart
+++ b/lib/pages/profile/widgets/profile_tab_purchase.dart
@@ -6,31 +6,29 @@ import 'package:child_goods_store_flutter/constants/sizes.dart';
 import 'package:child_goods_store_flutter/constants/strings.dart';
 import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
 import 'package:child_goods_store_flutter/enums/loading_status.dart';
-import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
-import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
 import 'package:child_goods_store_flutter/pages/profile/widgets/profile_tab_category_dropdown.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
-import 'package:child_goods_store_flutter/widgets/common/product_listitem.dart';
-import 'package:child_goods_store_flutter/widgets/common/together_listitem.dart';
+import 'package:child_goods_store_flutter/widgets/common/purchase_listitem.dart';
 import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class ProfileTabMyItem extends StatefulWidget {
+class ProfileTabPurchase extends StatefulWidget {
   final GlobalKey<ExtendedNestedScrollViewState> nestedScrollKey;
 
-  const ProfileTabMyItem({
+  const ProfileTabPurchase({
     super.key,
     required this.nestedScrollKey,
   });
 
   @override
-  State<ProfileTabMyItem> createState() => _ProfileTabMyItemState();
+  State<ProfileTabPurchase> createState() => _ProfileTabPurchaseState();
 }
 
-class _ProfileTabMyItemState extends State<ProfileTabMyItem>
-    with AutomaticKeepAliveClientMixin<ProfileTabMyItem> {
+class _ProfileTabPurchaseState extends State<ProfileTabPurchase>
+    with AutomaticKeepAliveClientMixin<ProfileTabPurchase> {
   @override
   bool get wantKeepAlive => true;
 
@@ -42,11 +40,11 @@ class _ProfileTabMyItemState extends State<ProfileTabMyItem>
 
   void _initLoadData() {
     var bloc = context.read<ProfileTabBloc>();
-    if (bloc.state.myProductsStatus == ELoadingStatus.init &&
+    if (bloc.state.purchaseProductsStatus == ELoadingStatus.init &&
         bloc.state.category == EChatItemType.product) {
       _loadData();
     }
-    if (bloc.state.myTogethersStatus == ELoadingStatus.init &&
+    if (bloc.state.purchaseTogethersStatus == ELoadingStatus.init &&
         bloc.state.category == EChatItemType.together) {
       _loadData();
     }
@@ -55,12 +53,12 @@ class _ProfileTabMyItemState extends State<ProfileTabMyItem>
   void _loadData({bool force = false}) {
     var bloc = context.read<ProfileTabBloc>();
     if (bloc.state.category == EChatItemType.product) {
-      if (bloc.state.myProductsStatus != ELoadingStatus.error || force) {
-        bloc.add(ProfileTabGetProducts());
+      if (bloc.state.purchaseProductsStatus != ELoadingStatus.error || force) {
+        bloc.add(ProfileTabGetPurchaseProducts());
       }
     } else {
-      if (bloc.state.myTogethersStatus != ELoadingStatus.error || force) {
-        bloc.add(ProfileTabGetTogethers());
+      if (bloc.state.purchaseTogethersStatus != ELoadingStatus.error || force) {
+        bloc.add(ProfileTabGetPurchaseTogethers());
       }
     }
   }
@@ -92,9 +90,9 @@ class _ProfileTabMyItemState extends State<ProfileTabMyItem>
               },
               builder: (context, state) {
                 if (state.category == EChatItemType.product) {
-                  return _productList(state.myProducts);
+                  return _itemList(state.purchaseProducts);
                 }
-                return _togetherList(state.myTogethers);
+                return _itemList(state.purchaseTogethers);
               },
             ),
           ),
@@ -112,19 +110,19 @@ class _ProfileTabMyItemState extends State<ProfileTabMyItem>
           child: BlocBuilder<ProfileTabBloc, ProfileTabState>(
             builder: (context, state) {
               if (state.category == EChatItemType.product &&
-                      state.myProductsStatus == ELoadingStatus.error ||
+                      state.purchaseProductsStatus == ELoadingStatus.error ||
                   state.category == EChatItemType.together &&
-                      state.myTogethersStatus == ELoadingStatus.error) {
+                      state.purchaseTogethersStatus == ELoadingStatus.error) {
                 return Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     if (state.category == EChatItemType.product)
                       AppFont(
-                        state.myProductsMessage ?? Strings.unknownFail,
+                        state.purchaseProductsMessage ?? Strings.unknownFail,
                       ),
                     if (state.category == EChatItemType.together)
                       AppFont(
-                        state.myTogethersMessage ?? Strings.unknownFail,
+                        state.purchaseTogethersMessage ?? Strings.unknownFail,
                       ),
                     Gaps.v20,
                     AppInkButton(
@@ -145,28 +143,13 @@ class _ProfileTabMyItemState extends State<ProfileTabMyItem>
     );
   }
 
-  Widget _productList(List<ProductPreviewModel> products) {
-    return SliverGrid.builder(
-      gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-        maxCrossAxisExtent: 300,
-        childAspectRatio: 2 / 3,
-        crossAxisSpacing: Sizes.size16,
-        mainAxisSpacing: Sizes.size16,
-      ),
-      itemBuilder: (context, index) => ProductListItem(
-        product: products[index],
-      ),
-      itemCount: products.length,
-    );
-  }
-
-  Widget _togetherList(List<TogetherPreviewModel> togethers) {
+  Widget _itemList(List<PurchaseModel> items) {
     return SliverList.separated(
-      itemBuilder: (context, index) => TogetherListItem(
-        together: togethers[index],
+      itemBuilder: (context, index) => PurchaseListItem(
+        purchase: items[index],
       ),
       separatorBuilder: (context, index) => Gaps.v16,
-      itemCount: togethers.length,
+      itemCount: items.length,
     );
   }
 }

--- a/lib/pages/profile/widgets/profile_tab_review.dart
+++ b/lib/pages/profile/widgets/profile_tab_review.dart
@@ -1,0 +1,106 @@
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_bloc.dart';
+import 'package:child_goods_store_flutter/blocs/profile/profile_tab_state.dart';
+import 'package:child_goods_store_flutter/constants/gaps.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/constants/strings.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/enums/loading_status.dart';
+import 'package:child_goods_store_flutter/widgets/app_font.dart';
+import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
+import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ProfileTabReview extends StatefulWidget {
+  final GlobalKey<ExtendedNestedScrollViewState> nestedScrollKey;
+
+  const ProfileTabReview({
+    super.key,
+    required this.nestedScrollKey,
+  });
+
+  @override
+  State<ProfileTabReview> createState() => _ProfileTabReviewState();
+}
+
+class _ProfileTabReviewState extends State<ProfileTabReview>
+    with AutomaticKeepAliveClientMixin<ProfileTabReview> {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification.metrics.pixels >=
+            notification.metrics.maxScrollExtent) {
+          // _loadData();
+        }
+        return false;
+      },
+      child: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: Sizes.size20,
+            ),
+            sliver: BlocBuilder<ProfileTabBloc, ProfileTabState>(
+              builder: (context, state) => SliverList.separated(
+                itemBuilder: (context, index) => Container(
+                  color: Colors.amber,
+                  child: AppFont('Review $index'),
+                ),
+                separatorBuilder: (context, index) => Gaps.v16,
+                itemCount: 20,
+              ),
+            ),
+          ),
+          _retryWidget(),
+        ],
+      ),
+    );
+  }
+
+  Widget _retryWidget() {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Sizes.size20),
+        child: Center(
+          child: BlocBuilder<ProfileTabBloc, ProfileTabState>(
+            builder: (context, state) {
+              if (state.category == EChatItemType.product &&
+                      state.myProductsStatus == ELoadingStatus.error ||
+                  state.category == EChatItemType.together &&
+                      state.myTogethersStatus == ELoadingStatus.error) {
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (state.category == EChatItemType.product)
+                      AppFont(
+                        state.myProductsMessage ?? Strings.unknownFail,
+                      ),
+                    if (state.category == EChatItemType.together)
+                      AppFont(
+                        state.myTogethersMessage ?? Strings.unknownFail,
+                      ),
+                    Gaps.v20,
+                    const AppInkButton(
+                      // onTap: () => _loadData(force: true),
+                      child: AppFont(
+                        '재시도',
+                        color: Colors.white,
+                      ),
+                    ),
+                  ],
+                );
+              }
+              return const CircularProgressIndicator();
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -82,6 +82,8 @@ class AuthRepository {
     return;
   }
 
+  ///
+  /// API 1
   Future<ResModel<String>> signinWithOauth2({
     required EAuthMethod method,
     required String accessToken,
@@ -112,6 +114,8 @@ class AuthRepository {
     return res;
   }
 
+  ///
+  /// API 2
   Future<ResModel<String>> signinWith3C1S({
     required String email,
     required String password,
@@ -142,6 +146,36 @@ class AuthRepository {
     return res;
   }
 
+  ///
+  /// API 3
+  Future<ResModel<void>> postSignup({
+    required String email,
+    required String password,
+    // required String phoneNum,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(UnAuthInterceptor());
+    // dio.post(
+    //   '/signup',
+    //   data: {
+    //     'email': email,
+    //     'password': password,
+    //     'phoneNum': phoneNum,
+    //   }
+    // );
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<void>(code: 1000).toJson((p0) => null);
+
+    var res = ResModel<void>.fromJson(resTmp, (json) {});
+
+    return res;
+  }
+
+  ///
+  /// API 4
   Future<ResModel<void>> postEmailSend({
     required String email,
   }) async {
@@ -164,6 +198,8 @@ class AuthRepository {
     return res;
   }
 
+  ///
+  /// API 5
   Future<ResModel<void>> postEmailVerify({
     required String email,
     required String code,
@@ -176,32 +212,6 @@ class AuthRepository {
     //     'email': email,
     //     'authNum': code,
     //   },
-    // );
-
-    // TODO: connect api
-    await Future.delayed(const Duration(seconds: 1));
-
-    var resTmp = ResModel<void>(code: 1000).toJson((p0) => null);
-
-    var res = ResModel<void>.fromJson(resTmp, (json) {});
-
-    return res;
-  }
-
-  Future<ResModel<void>> postSignup({
-    required String email,
-    required String password,
-    // required String phoneNum,
-  }) async {
-    // Dio dio = Dio();
-    // dio.interceptors.add(UnAuthInterceptor());
-    // dio.post(
-    //   '/signup',
-    //   data: {
-    //     'email': email,
-    //     'password': password,
-    //     'phoneNum': phoneNum,
-    //   }
     // );
 
     // TODO: connect api

--- a/lib/repositories/child_repository.dart
+++ b/lib/repositories/child_repository.dart
@@ -9,6 +9,8 @@ import 'package:child_goods_store_flutter/utils/mock_dio_exception.dart';
 import 'package:dio/dio.dart';
 
 class ChildRepository {
+  ///
+  /// API 11
   Future<ResModel<List<ChildModel>>> getChild() async {
     // Dio dio = Dio();
     // dio.interceptors.add(AuthInterceptor());
@@ -53,6 +55,8 @@ class ChildRepository {
     return res;
   }
 
+  ///
+  /// API 12
   Future<ResModel<ChildModel>> postChild({
     required ChildModel child,
   }) async {
@@ -88,6 +92,8 @@ class ChildRepository {
     return res;
   }
 
+  ///
+  /// API 13
   Future<ResModel<ChildModel>> patchChild({
     required ChildModel child,
   }) async {
@@ -123,6 +129,7 @@ class ChildRepository {
     return res;
   }
 
+  /// API 102
   Future<ResModel<List<ProductPreviewModel>>> getChildProductList({
     required int childId,
   }) async {

--- a/lib/repositories/data_repository.dart
+++ b/lib/repositories/data_repository.dart
@@ -25,6 +25,8 @@ class DataRepository {
     return districtData;
   }
 
+  ///
+  /// API 17
   Future<ResModel<List<AddressModel>>> getAddress() async {
     // Dio dio = Dio();
     // dio.interceptors.add(AuthInterceptor());
@@ -61,6 +63,8 @@ class DataRepository {
     return res;
   }
 
+  ///
+  /// API 18
   Future<ResModel<AddressModel>> postAddress({
     required AddressModel address,
   }) async {
@@ -92,6 +96,8 @@ class DataRepository {
     return res;
   }
 
+  ///
+  /// API 19
   Future<ResModel<AddressModel>> patchAddress({
     required AddressModel address,
   }) async {

--- a/lib/repositories/product_repository.dart
+++ b/lib/repositories/product_repository.dart
@@ -16,6 +16,8 @@ import 'package:child_goods_store_flutter/utils/mock_dio_exception.dart';
 import 'package:dio/dio.dart';
 
 class ProductRepository {
+  ///
+  /// API 101
   Future<ResModel<List<ProductPreviewModel>>> getProductList({
     required ESearchRange region,
     EMainCategory? mainCategory,
@@ -85,6 +87,8 @@ class ProductRepository {
     return res;
   }
 
+  ///
+  /// API 106
   Future<ResModel<ProductModel>> getProduct({
     required int productId,
   }) async {
@@ -131,6 +135,106 @@ class ProductRepository {
     return res;
   }
 
+  ///
+  /// API 107
+  Future<ResModel<void>> postProductHeart({
+    required int productId,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.post('/product/heart/$productId');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel(code: 1000).toJson((p0) => null);
+
+    var res = ResModel.fromJson(resTmp, (json) => null);
+
+    return res;
+  }
+
+  ///
+  /// API 108
+  Future<ResModel<void>> deleteProductHeart({
+    required int productId,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.delete('/product/heart/$productId');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel(code: 1000).toJson((p0) => null);
+
+    var res = ResModel.fromJson(resTmp, (json) => null);
+
+    return res;
+  }
+
+  ///
+  /// API 109
+  Future<ResModel<int>> postProduct({
+    required ProductModel product,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.post(
+    //   '/product',
+    //   data: product.toJson(),
+    // );
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<int>(
+      code: 1000,
+      data: 999,
+    ).toJson(
+      (id) => id.toString(),
+    );
+
+    var res = ResModel<int>.fromJson(
+      resTmp,
+      (json) => int.parse(json),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 110
+  Future<ResModel<int>> patchProduct({
+    required ProductModel product,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.patch(
+    //   '/product/${product.productId}',
+    //   data: product.toJson(),
+    // );
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<int>(
+      code: 1000,
+      data: product.productId,
+    ).toJson(
+      (id) => id.toString(),
+    );
+
+    var res = ResModel<int>.fromJson(
+      resTmp,
+      (json) => int.parse(json),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 111
   Future<ResModel<void>> postProductState({
     required int productId,
     required EProductSaleState state,
@@ -156,40 +260,8 @@ class ProductRepository {
     return res;
   }
 
-  Future<ResModel<void>> postProductHeart({
-    required int productId,
-  }) async {
-    // Dio dio = Dio();
-    // dio.interceptors.add(AuthInterceptor());
-    // dio.post('/product/heart/$productId');
-
-    // TODO: connect api
-    await Future.delayed(const Duration(seconds: 1));
-
-    var resTmp = ResModel(code: 1000).toJson((p0) => null);
-
-    var res = ResModel.fromJson(resTmp, (json) => null);
-
-    return res;
-  }
-
-  Future<ResModel<void>> deleteProductHeart({
-    required int productId,
-  }) async {
-    // Dio dio = Dio();
-    // dio.interceptors.add(AuthInterceptor());
-    // dio.delete('/product/heart/$productId');
-
-    // TODO: connect api
-    await Future.delayed(const Duration(seconds: 1));
-
-    var resTmp = ResModel(code: 1000).toJson((p0) => null);
-
-    var res = ResModel.fromJson(resTmp, (json) => null);
-
-    return res;
-  }
-
+  ///
+  /// API 112
   Future<ResModel<List<UserProfileModel>>> getProductBuyer({
     required int productId,
   }) async {
@@ -228,62 +300,6 @@ class ProductRepository {
       (json) => (json as List<dynamic>)
           .map((user) => UserProfileModel.fromJson(user))
           .toList(),
-    );
-
-    return res;
-  }
-
-  Future<ResModel<int>> postProduct({
-    required ProductModel product,
-  }) async {
-    // Dio dio = Dio();
-    // dio.interceptors.add(AuthInterceptor());
-    // dio.post(
-    //   '/product',
-    //   data: product.toJson(),
-    // );
-
-    // TODO: connect api
-    await Future.delayed(const Duration(seconds: 1));
-
-    var resTmp = ResModel<int>(
-      code: 1000,
-      data: 999,
-    ).toJson(
-      (id) => id.toString(),
-    );
-
-    var res = ResModel<int>.fromJson(
-      resTmp,
-      (json) => int.parse(json),
-    );
-
-    return res;
-  }
-
-  Future<ResModel<int>> patchProduct({
-    required ProductModel product,
-  }) async {
-    // Dio dio = Dio();
-    // dio.interceptors.add(AuthInterceptor());
-    // dio.post(
-    //   '/product/${product.productId}',
-    //   data: product.toJson(),
-    // );
-
-    // TODO: connect api
-    await Future.delayed(const Duration(seconds: 1));
-
-    var resTmp = ResModel<int>(
-      code: 1000,
-      data: product.productId,
-    ).toJson(
-      (id) => id.toString(),
-    );
-
-    var res = ResModel<int>.fromJson(
-      resTmp,
-      (json) => int.parse(json),
     );
 
     return res;

--- a/lib/repositories/profile_repository.dart
+++ b/lib/repositories/profile_repository.dart
@@ -1,0 +1,255 @@
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/enums/product_sale_state.dart';
+import 'package:child_goods_store_flutter/interceptors/auth_interceptor.dart';
+import 'package:child_goods_store_flutter/interceptors/un_auth_interceptor.dart';
+import 'package:child_goods_store_flutter/models/product/product_preview_model.dart';
+import 'package:child_goods_store_flutter/models/res/res_model.dart';
+import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
+import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:dio/dio.dart';
+
+class ProfileRepository {
+  ///
+  /// API 103
+  Future<ResModel<List<ProductPreviewModel>>> getProfileProductList({
+    required int userId,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(UnAuthInterceptor());
+    // dio.get('/profile/product/$userId');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<ProductPreviewModel>>(
+      code: 1000,
+      data: [
+        for (var productId in List.generate(10, (index) => index + 1))
+          ProductPreviewModel(
+            productId: productId,
+            productName: '$productId th product',
+            price: 12000,
+            state: EProductSaleState.sale,
+            productImage: productId % 3 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
+            productHeart: productId % 3 == 0 ? false : true,
+          ),
+      ],
+    ).toJson(
+      (products) => products.map((prod) => prod.toJson()).toList(),
+    );
+
+    var res = ResModel<List<ProductPreviewModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => ProductPreviewModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 104
+  Future<ResModel<List<ProductPreviewModel>>>
+      getProfileProductHeartList() async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.get('/profile/product/heart');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<ProductPreviewModel>>(
+      code: 1000,
+      data: [
+        for (var productId in List.generate(10, (index) => index + 1))
+          ProductPreviewModel(
+            productId: productId,
+            productName: '$productId th product',
+            price: 12000,
+            state: EProductSaleState.sale,
+            productImage: productId % 3 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
+            productHeart: true,
+          ),
+      ],
+    ).toJson(
+      (products) => products.map((prod) => prod.toJson()).toList(),
+    );
+
+    var res = ResModel<List<ProductPreviewModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => ProductPreviewModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 105
+  Future<ResModel<List<PurchaseModel>>> getProfileProductPurchaseList() async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.get('/profile/product/purchase');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<PurchaseModel>>(
+      code: 1000,
+      data: [
+        for (var productId in List.generate(10, (index) => index + 1))
+          PurchaseModel(
+            category: EChatItemType.product,
+            id: productId,
+            name: '$productId name',
+            sellerName: '$productId saller name',
+            price: 10000,
+            saleCompleteDate: DateTime.now(),
+            isReview: productId % 3 == 0 ? false : true,
+          ),
+      ],
+    ).toJson(
+      (products) => products.map((prod) => prod.toJson()).toList(),
+    );
+
+    var res = ResModel<List<PurchaseModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => PurchaseModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 202
+  Future<ResModel<List<TogetherPreviewModel>>> getProfileTogetherList({
+    required int userId,
+  }) async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(UnAuthInterceptor());
+    // dio.get('/profile/together/$userId');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<TogetherPreviewModel>>(
+      code: 1000,
+      data: [
+        for (var togetherId in List.generate(10, (index) => index + 1))
+          TogetherPreviewModel(
+            togetherId: togetherId,
+            togetherName: '$togetherId th Together',
+            totalPrice: 120000,
+            purchasePrice: 1200,
+            totalNum: 100,
+            purchaseNum: 6 * togetherId,
+            deadline: DateTime.now(),
+            togetherImage: togetherId % 3 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
+            togetherHeart: togetherId % 3 == 0 ? false : true,
+          ),
+      ],
+    ).toJson(
+      (togethers) => togethers.map((tgd) => tgd.toJson()).toList(),
+    );
+
+    var res = ResModel<List<TogetherPreviewModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => TogetherPreviewModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 203
+  Future<ResModel<List<TogetherPreviewModel>>>
+      getProfileTogetherHeartList() async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.get('/profile/together/heart');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<TogetherPreviewModel>>(
+      code: 1000,
+      data: [
+        for (var togetherId in List.generate(10, (index) => index + 1))
+          TogetherPreviewModel(
+            togetherId: togetherId,
+            togetherName: '$togetherId th Together',
+            totalPrice: 120000,
+            purchasePrice: 1200,
+            totalNum: 100,
+            purchaseNum: 6 * togetherId,
+            deadline: DateTime.now(),
+            togetherImage: togetherId % 3 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
+            togetherHeart: true,
+          ),
+      ],
+    ).toJson(
+      (togethers) => togethers.map((tgd) => tgd.toJson()).toList(),
+    );
+
+    var res = ResModel<List<TogetherPreviewModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => TogetherPreviewModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+
+  ///
+  /// API 204
+  Future<ResModel<List<PurchaseModel>>> getProfileTogetherPurchaseList() async {
+    // Dio dio = Dio();
+    // dio.interceptors.add(AuthInterceptor());
+    // dio.get('/profile/together/purchase');
+
+    // TODO: connect api
+    await Future.delayed(const Duration(seconds: 1));
+
+    var resTmp = ResModel<List<PurchaseModel>>(
+      code: 1000,
+      data: [
+        for (var togetherId in List.generate(10, (index) => index + 1))
+          PurchaseModel(
+            category: EChatItemType.together,
+            id: togetherId,
+            name: '$togetherId name',
+            sellerName: '$togetherId saller name',
+            price: 10000,
+            saleCompleteDate: DateTime.now(),
+            isReview: togetherId % 3 == 0 ? false : true,
+          ),
+      ],
+    ).toJson(
+      (products) => products.map((prod) => prod.toJson()).toList(),
+    );
+
+    var res = ResModel<List<PurchaseModel>>.fromJson(
+      resTmp,
+      (json) => (json as List<dynamic>)
+          .map((prod) => PurchaseModel.fromJson(prod))
+          .toList(),
+    );
+
+    return res;
+  }
+}

--- a/lib/repositories/profile_repository.dart
+++ b/lib/repositories/profile_repository.dart
@@ -6,6 +6,7 @@ import 'package:child_goods_store_flutter/models/product/product_preview_model.d
 import 'package:child_goods_store_flutter/models/res/res_model.dart';
 import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
 import 'package:child_goods_store_flutter/models/together/together_preview_model.dart';
+import 'package:child_goods_store_flutter/utils/mock_dio_exception.dart';
 import 'package:dio/dio.dart';
 
 class ProfileRepository {
@@ -111,6 +112,9 @@ class ProfileRepository {
             sellerName: '$productId saller name',
             price: 10000,
             saleCompleteDate: DateTime.now(),
+            image: productId % 4 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
             isReview: productId % 3 == 0 ? false : true,
           ),
       ],
@@ -236,6 +240,9 @@ class ProfileRepository {
             sellerName: '$togetherId saller name',
             price: 10000,
             saleCompleteDate: DateTime.now(),
+            image: togetherId % 4 == 0
+                ? ''
+                : 'https://lh4.googleusercontent.com/on7Yj1rShJRRBy88rTmptLVzMI4gEBDBabmSMv-GGsPIo5umfS5dpSJp3b4EoqKtnxdOYXeHSyct6m2fLYKckaikrUJn91PNWkIYXtkrCljcvdEnGdf_nQM5Qw6bQY4q6jvbWiBcC3WPTIcDS_lizv3R25oVAF_H0PNzvRo7JivPSiZR',
             isReview: togetherId % 3 == 0 ? false : true,
           ),
       ],

--- a/lib/repositories/search_repository.dart
+++ b/lib/repositories/search_repository.dart
@@ -3,6 +3,8 @@ import 'package:child_goods_store_flutter/models/res/res_model.dart';
 import 'package:dio/dio.dart';
 
 class SearchRepository {
+  ///
+  /// API 24
   Future<ResModel<List<String>>> seatchTag({
     required String query,
   }) async {

--- a/lib/repositories/together_repository.dart
+++ b/lib/repositories/together_repository.dart
@@ -15,6 +15,8 @@ import 'package:child_goods_store_flutter/utils/mock_dio_exception.dart';
 import 'package:dio/dio.dart';
 
 class TogetherRepository {
+  ///
+  /// API 201
   Future<ResModel<List<TogetherPreviewModel>>> getTogetherList({
     required ESearchRange region,
     EMainCategory? mainCategory,
@@ -79,6 +81,8 @@ class TogetherRepository {
     return res;
   }
 
+  ///
+  /// API 205
   Future<ResModel<TogetherModel>> getTogether({
     required int togetherId,
   }) async {
@@ -129,6 +133,8 @@ class TogetherRepository {
     return res;
   }
 
+  ///
+  ///  API 206
   Future<ResModel<void>> postTogetherHeart({
     required int togetherId,
   }) async {
@@ -146,6 +152,8 @@ class TogetherRepository {
     return res;
   }
 
+  ///
+  /// API 207
   Future<ResModel<void>> deleteTogetherHeart({
     required int togetherId,
   }) async {
@@ -163,6 +171,7 @@ class TogetherRepository {
     return res;
   }
 
+  /// API 208
   Future<ResModel<int>> postTogether({
     required TogetherModel together,
   }) async {
@@ -191,6 +200,7 @@ class TogetherRepository {
     return res;
   }
 
+  /// API 209
   Future<ResModel<int>> patchTogether({
     required TogetherModel together,
   }) async {

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -8,6 +8,8 @@ import 'package:child_goods_store_flutter/utils/mock_dio_exception.dart';
 import 'package:dio/dio.dart';
 
 class UserRepository {
+  ///
+  /// API 6
   Future<ResModel<UserModel>> getUser() async {
     // Dio dio = Dio();
     // dio.interceptors.add(AuthInterceptor());
@@ -40,6 +42,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 7
   Future<ResModel<UserModel>> postUser({
     required UserModel user,
   }) async {
@@ -68,6 +72,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 8
   Future<ResModel<UserModel>> patchUser({
     required UserModel user,
   }) async {
@@ -96,6 +102,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 9
   Future<ResModel<UserProfileModel>> getMyProfile() async {
     // Dio dio = Dio();
     // dio.interceptors.add(AuthInterceptor());
@@ -128,6 +136,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 10
   Future<ResModel<UserProfileModel>> getUserProfile({
     required int userId,
   }) async {
@@ -163,6 +173,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 20
   Future<ResModel<List<UserModel>>> getUserFollower({
     required int userId,
   }) async {
@@ -206,6 +218,8 @@ class UserRepository {
     return res;
   }
 
+  ///
+  /// API 21
   Future<ResModel<List<UserModel>>> getUserFollowing({
     required int userId,
   }) async {

--- a/lib/widgets/app_network_image.dart
+++ b/lib/widgets/app_network_image.dart
@@ -29,14 +29,16 @@ class AppNetworkImage extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Icon(
-                    Icons.cancel_rounded,
+                    Icons.image_not_supported_rounded,
                     size: Sizes.size40,
-                    color: Colors.redAccent.withOpacity(0.5),
+                    color: Colors.black87.withOpacity(0.5),
                   ),
                   Gaps.v10,
-                  const AppFont(
+                  AppFont(
                     '제공되는 이미지가\n없습니다 :(',
                     textAlign: TextAlign.center,
+                    fontSize: Sizes.size10,
+                    color: Colors.black87.withOpacity(0.5),
                   ),
                 ],
               ),

--- a/lib/widgets/common/purchase_listitem.dart
+++ b/lib/widgets/common/purchase_listitem.dart
@@ -1,0 +1,147 @@
+import 'package:child_goods_store_flutter/constants/gaps.dart';
+import 'package:child_goods_store_flutter/constants/routes.dart';
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/constants/strings.dart';
+import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
+import 'package:child_goods_store_flutter/models/purchase/purchase_model.dart';
+import 'package:child_goods_store_flutter/widgets/app_font.dart';
+import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
+import 'package:child_goods_store_flutter/widgets/app_network_image.dart';
+import 'package:child_goods_store_flutter/utils/other_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class PurchaseListItem extends StatelessWidget {
+  final PurchaseModel purchase;
+
+  const PurchaseListItem({
+    super.key,
+    required this.purchase,
+  });
+
+  void _pushItem(BuildContext context) {
+    if (purchase.category == EChatItemType.product) {
+      context.push('${Routes.productDetail}/${purchase.id}');
+    }
+    if (purchase.category == EChatItemType.together) {
+      context.push('${Routes.togetherDetail}/${purchase.id}');
+    }
+  }
+
+  void _pushReview(BuildContext context) {
+    print('Push review for ${purchase.id}');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.hardEdge,
+      decoration: BoxDecoration(
+        color: Theme.of(context).scaffoldBackgroundColor,
+        borderRadius: BorderRadius.circular(Sizes.size10),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).shadowColor.withOpacity(0.1),
+            blurRadius: Sizes.size3,
+            spreadRadius: Sizes.size1,
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            height: 150,
+            child: AppInkButton(
+              onTap: () => _pushItem(context),
+              padding: const EdgeInsets.all(Sizes.size5),
+              borderRadSize: 0,
+              color: Colors.transparent,
+              shadowColor: Colors.transparent,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Flexible(
+                    flex: 1,
+                    child: Container(
+                      clipBehavior: Clip.hardEdge,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(Sizes.size5),
+                      ),
+                      child: AppNetworkImage(
+                        profileImg: purchase.image,
+                        height: 150,
+                      ),
+                    ),
+                  ),
+                  Flexible(
+                    flex: 2,
+                    child: Container(
+                      clipBehavior: Clip.hardEdge,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: Sizes.size10,
+                      ),
+                      decoration: const BoxDecoration(),
+                      child: SingleChildScrollView(
+                        physics: const NeverScrollableScrollPhysics(),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Gaps.v5,
+                            AppFont(purchase.name ?? Strings.nullStr),
+                            Gaps.v5,
+                            const AppFont(
+                              '구매가',
+                              fontSize: Sizes.size7,
+                            ),
+                            AppFont(
+                              '${purchase.price?.price()} 원',
+                              fontWeight: FontWeight.w700,
+                            ),
+                            const AppFont(
+                              '판매자',
+                              fontSize: Sizes.size7,
+                            ),
+                            AppFont(purchase.sellerName ?? Strings.nullStr),
+                            const AppFont(
+                              '거래일',
+                              fontSize: Sizes.size7,
+                            ),
+                            AppFont(purchase.saleCompleteDate
+                                .toString()
+                                .split(' ')
+                                .first),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: Sizes.size5),
+                      child: Icon(
+                        Icons.keyboard_arrow_right_rounded,
+                        color: Colors.black87.withOpacity(0.5),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (purchase.isReview != true)
+            AppInkButton(
+              onTap: () => _pushReview(context),
+              borderRadSize: 0,
+              child: const AppFont(
+                '리뷰 남기기',
+                color: Colors.white,
+                textAlign: TextAlign.center,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  extended_nested_scroll_view:
+    dependency: "direct main"
+    description:
+      name: extended_nested_scroll_view
+      sha256: "835580d40c2c62b448bd14adecd316acba469ba61f1510ef559d17668a85e777"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -1250,6 +1258,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  visibility_detector:
+    dependency: transitive
+    description:
+      name: visibility_detector
+      sha256: dd5cc11e13494f432d15939c3aa8ae76844c42b723398643ce9addb88a5ed420
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0+2"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   kpostal: ^0.5.1
   carousel_slider: ^4.2.1
   percent_indicator: ^4.2.3
+  extended_nested_scroll_view: ^6.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 개요

내 정보 페이지의 탭을 구현 완료했습니다.

Resolves #27 

### 추가사항

- 거래 아이템을 분류할 `EChatItemType` 추가
- 게시한 글, 관심 목록, 구매 내역, 받은 후기(미구현) 탭 추가 
- Repository 인덱싱용 주석 추가

### 변경사항 및 이유

- 중고거래 상태 변경시 거래자 목록 조회 호출시점 변경
  거래자 목록 조회 시점을 `거래 완료` 버튼을 눌렀을 때 조회하도록 변경하여 불필요한 API 호출 방지
- Resository 메서드 순서 변경
  인덱싱 주석을 추가함에 따라 인덱스 순서대로 재배열