### PR TITLE
Fix EditTogetherDeadline minimumDate exception

### DIFF
--- a/lib/pages/edit_together/widgets/edit_together_deadline.dart
+++ b/lib/pages/edit_together/widgets/edit_together_deadline.dart
@@ -27,10 +27,17 @@ class _EditTogetherDeadlineState extends State<EditTogetherDeadline> {
           initialDateTime:
               context.read<EditTogetherBloc>().state.together.deadline ??
                   DateTime.now(),
-          minimumDate: DateTime.now(),
-          maximumDate: DateTime.now().add(const Duration(days: 365)),
+          minimumDate: DateTime.now().copyWith(
+            hour: 0,
+            minute: 0,
+            second: 0,
+            millisecond: 0,
+            microsecond: 0,
+          ),
           mode: CupertinoDatePickerMode.date,
           onDateTimeChanged: (DateTime value) {
+            // Validate
+            if (value.difference(DateTime.now()).inMilliseconds < 0) return;
             context
                 .read<EditTogetherBloc>()
                 .add(EditTogetherChangeDeadline(value));


### PR DESCRIPTION
### 개요

`initialDateTime`이 `minimumDate`보다 작아 예외가 발생하는 버그 수정.

Resolves: #31 

### 추가사항

N/A

### 변경사항 및 이유

- `onDateTimeChanged`의 Validation 추가
  오늘보다 이전 날짜가 선택되는 경우 반영되지 않도록 조건문 로직 추가.
  그리고 `minimumDate`의 `hour` 이하 단위의 시간은 0으로 세팅
