### PR TITLE
Feat: "implement chat business logic"

### DIFF
--- a/lib/app_home_route.dart
+++ b/lib/app_home_route.dart
@@ -1,0 +1,194 @@
+part of child_goods_store_flutter_app_router;
+
+StatefulShellRoute _appHomeRoute() {
+  return StatefulShellRoute.indexedStack(
+    pageBuilder: (context, state, navigationShell) => PageTransition.cupertino(
+      key: state.pageKey,
+      // ignore `name` field for disable GA
+      child: BlocListener<FCMCubit, FCMState>(
+        bloc: FCMCubitSingleton.cubit,
+        listener: (context, state) {
+          if (state.data != null) {
+            // TODO: Replace event
+            AppSnackbar.show(
+              context,
+              message: state.body ?? Strings.unknownFail,
+            );
+          }
+          context.go(
+            '${Routes.chat}/${SubRoutes.chatRoom}',
+            extra: const GoRouterExtraModel<int>(data: 1),
+          );
+        },
+        child: Scaffold(
+          body: navigationShell,
+          bottomNavigationBar: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+            height: state.uri.toString().contains(SubRoutes.chatRoom)
+                ? 0
+                : Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+            decoration: BoxDecoration(
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.1),
+                  blurRadius: Sizes.size3,
+                  spreadRadius: Sizes.size1,
+                ),
+              ],
+            ),
+            clipBehavior: Clip.hardEdge,
+            child: SingleChildScrollView(
+              physics: const NeverScrollableScrollPhysics(),
+              child: SizedBox(
+                height: Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+                child: BottomNavigationBar(
+                  enableFeedback: false,
+                  type: BottomNavigationBarType.fixed,
+                  unselectedLabelStyle: const TextStyle(fontSize: Sizes.size8),
+                  selectedLabelStyle: const TextStyle(fontSize: Sizes.size10),
+                  selectedIconTheme: const IconThemeData(size: Sizes.size28),
+                  items: [
+                    const BottomNavigationBarItem(
+                      label: '중고거래',
+                      icon: Icon(Icons.home),
+                    ),
+                    BottomNavigationBarItem(
+                      label: '공동구매',
+                      icon: Transform.scale(
+                        scale: 0.8,
+                        child: const Icon(FontAwesomeIcons.boxesStacked),
+                      ),
+                    ),
+                    const BottomNavigationBarItem(
+                      label: '자녀',
+                      icon: Icon(Icons.child_care_rounded),
+                    ),
+                    const BottomNavigationBarItem(
+                      label: '채팅',
+                      icon: Icon(Icons.chat_rounded),
+                    ),
+                    const BottomNavigationBarItem(
+                      label: '내 정보',
+                      icon: Icon(Icons.person_rounded),
+                    ),
+                  ],
+                  currentIndex: navigationShell.currentIndex,
+                  onTap: (value) => navigationShell.goBranch(value),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+    branches: [
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            name: Routes.product,
+            path: Routes.product,
+            builder: (context, state) => BlocProvider(
+              create: (context) => ProductListBloc(
+                productRepository: context.read<IProductRepository>(),
+              ),
+              child: const ProductPage(),
+            ),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            name: Routes.together,
+            path: Routes.together,
+            builder: (context, state) => BlocProvider(
+              create: (context) => TogetherListBloc(
+                togetherRepository: context.read<ITogetherRepository>(),
+              ),
+              child: const TogetherPage(),
+            ),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            name: Routes.child,
+            path: Routes.child,
+            builder: (context, state) => BlocProvider(
+              create: (context) => ChildBloc(
+                childRepository: context.read<IChildRepository>(),
+              ),
+              child: const ChildPage(),
+            ),
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            name: Routes.chat,
+            path: Routes.chat,
+            builder: (context, state) => BlocProvider(
+              create: (context) => ChatListBloc(
+                chatRepository: context.read<IChatRepository>(),
+              ),
+              child: const ChatPage(),
+            ),
+            routes: [
+              GoRoute(
+                path: SubRoutes.chatRoom,
+                pageBuilder: (context, state) => PageTransition.cupertino(
+                  key: state.pageKey,
+                  name: state.fullPath,
+                  arguments: {
+                    'id': (state.extra as GoRouterExtraModel<int>).data ?? -1
+                  },
+                  child: BlocProvider(
+                    create: (context) => ChatRoomBloc(
+                      chatRepository: context.read<IChatRepository>(),
+                      productRepository: context.read<IProductRepository>(),
+                      togetherRepository: context.read<ITogetherRepository>(),
+                      chatRoomId:
+                          (state.extra as GoRouterExtraModel<int>).data ?? -1,
+                    ),
+                    child: const ChatRoomPage(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      StatefulShellBranch(
+        routes: [
+          GoRoute(
+            name: Routes.profile,
+            path: Routes.profile,
+            builder: (context, state) => MultiBlocProvider(
+              providers: [
+                BlocProvider(
+                  create: (context) => ProfileBloc(
+                    userRepository: context.read<IUserRepository>(),
+                    userId: AuthBlocSingleton.bloc.state.user!.userId!,
+                  ),
+                ),
+                BlocProvider(
+                  create: (context) => ProfileTabBloc(
+                    profileRepository: context.read<IProfileRepository>(),
+                    reviewRepository: context.read<IReviewRepository>(),
+                    userId: AuthBlocSingleton.bloc.state.user!.userId!,
+                  ),
+                ),
+              ],
+              child: const ProfilePage(
+                popAble: false,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/app_home_route.dart
+++ b/lib/app_home_route.dart
@@ -15,10 +15,6 @@ StatefulShellRoute _appHomeRoute() {
               message: state.body ?? Strings.unknownFail,
             );
           }
-          context.go(
-            '${Routes.chat}/${SubRoutes.chatRoom}',
-            extra: const GoRouterExtraModel<int>(data: 1),
-          );
         },
         child: Scaffold(
           body: navigationShell,
@@ -138,12 +134,12 @@ StatefulShellRoute _appHomeRoute() {
             ),
             routes: [
               GoRoute(
-                path: SubRoutes.chatRoom,
+                path: '${SubRoutes.chatRoom}/:chatRoomId',
                 pageBuilder: (context, state) => PageTransition.cupertino(
                   key: state.pageKey,
                   name: state.fullPath,
                   arguments: {
-                    'id': (state.extra as GoRouterExtraModel<int>).data ?? -1
+                    'id': int.parse(state.pathParameters['chatRoomId'] ?? '-1'),
                   },
                   child: BlocProvider(
                     create: (context) => ChatRoomBloc(
@@ -151,7 +147,7 @@ StatefulShellRoute _appHomeRoute() {
                       productRepository: context.read<IProductRepository>(),
                       togetherRepository: context.read<ITogetherRepository>(),
                       chatRoomId:
-                          (state.extra as GoRouterExtraModel<int>).data ?? -1,
+                          int.parse(state.pathParameters['chatRoomId'] ?? '-1'),
                     ),
                     child: const ChatRoomPage(),
                   ),

--- a/lib/app_home_route.dart
+++ b/lib/app_home_route.dart
@@ -17,13 +17,16 @@ StatefulShellRoute _appHomeRoute() {
           }
         },
         child: Scaffold(
-          body: navigationShell,
+          body: MediaQuery.removeViewPadding(
+            context: context,
+            child: navigationShell,
+          ),
           bottomNavigationBar: AnimatedContainer(
             duration: const Duration(milliseconds: 200),
             curve: Curves.easeOut,
             height: state.uri.toString().contains(SubRoutes.chatRoom)
                 ? 0
-                : Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+                : Sizes.size60 + MediaQuery.viewPaddingOf(context).bottom,
             decoration: BoxDecoration(
               boxShadow: [
                 BoxShadow(
@@ -37,7 +40,7 @@ StatefulShellRoute _appHomeRoute() {
             child: SingleChildScrollView(
               physics: const NeverScrollableScrollPhysics(),
               child: SizedBox(
-                height: Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+                height: Sizes.size60 + MediaQuery.viewPaddingOf(context).bottom,
                 child: BottomNavigationBar(
                   enableFeedback: false,
                   type: BottomNavigationBarType.fixed,

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -476,6 +476,7 @@ class _AppRouterState extends State<AppRouter> {
       debugShowCheckedModeBanner: false,
       title: F.title,
       theme: ThemeData(
+        platform: TargetPlatform.iOS,
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.white).copyWith(
           background: Colors.white,
         ),

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -90,6 +90,15 @@ class AppRouter extends StatefulWidget {
 class _AppRouterState extends State<AppRouter> {
   late GoRouter _routerConfig;
 
+  // App start route after splash
+  String _appStartRoute() {
+    if (FCMCubitSingleton.cubit.state.data?.code == 1000) {
+      FCMCubitSingleton.cubit.resetFCM();
+      return '${Routes.chat}/${SubRoutes.chatRoom}/1';
+    }
+    return Routes.product;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -126,7 +135,7 @@ class _AppRouterState extends State<AppRouter> {
         }
         if (authState.authStatus == EAuthStatus.authenticated) {
           return blockPageInAuthState.contains(state.uri.toString())
-              ? Routes.product
+              ? _appStartRoute()
               : state.uri.toString();
         }
         return state.uri.toString();
@@ -239,31 +248,30 @@ class _AppRouterState extends State<AppRouter> {
             key: state.pageKey,
             name: state.fullPath,
             arguments: {
-              'id': int.parse(state.pathParameters['productId'] as String),
+              'id': int.parse(state.pathParameters['productId'] ?? '-1'),
             },
             child: BlocProvider(
               create: (context) => ProductDetailBloc(
                 productRepository: context.read<IProductRepository>(),
-                productId:
-                    int.parse(state.pathParameters['productId'] as String),
+                productId: int.parse(state.pathParameters['productId'] ?? '-1'),
               ),
               child: const ProductDetailPage(),
             ),
           ),
         ),
         GoRoute(
-          path: '${Routes.together}/:togetherId',
+          path: '${Routes.togetherDetail}/:togetherId',
           pageBuilder: (context, state) => PageTransition.cupertino(
             key: state.pageKey,
             name: state.fullPath,
             arguments: {
-              'id': int.parse(state.pathParameters['togetherId'] as String),
+              'id': int.parse(state.pathParameters['togetherId'] ?? '-1'),
             },
             child: BlocProvider(
               create: (context) => TogetherDetailBloc(
                 togetherRepository: context.read<ITogetherRepository>(),
                 togetherId:
-                    int.parse(state.pathParameters['togetherId'] as String),
+                    int.parse(state.pathParameters['togetherId'] ?? '-1'),
               ),
               child: const TogetherDetailPage(),
             ),
@@ -275,21 +283,21 @@ class _AppRouterState extends State<AppRouter> {
             key: state.pageKey,
             name: state.fullPath,
             arguments: {
-              'id': int.parse(state.pathParameters['userId'] as String),
+              'id': int.parse(state.pathParameters['userId'] ?? '-1'),
             },
             child: MultiBlocProvider(
               providers: [
                 BlocProvider(
                   create: (context) => ProfileBloc(
                     userRepository: context.read<IUserRepository>(),
-                    userId: int.parse(state.pathParameters['userId'] as String),
+                    userId: int.parse(state.pathParameters['userId'] ?? '-1'),
                   ),
                 ),
                 BlocProvider(
                   create: (context) => ProfileTabBloc(
                     profileRepository: context.read<IProfileRepository>(),
                     reviewRepository: context.read<IReviewRepository>(),
-                    userId: int.parse(state.pathParameters['userId'] as String),
+                    userId: int.parse(state.pathParameters['userId'] ?? '-1'),
                   ),
                 ),
               ],
@@ -305,12 +313,12 @@ class _AppRouterState extends State<AppRouter> {
             key: state.pageKey,
             name: state.fullPath,
             arguments: {
-              'id': int.parse(state.pathParameters['userId'] as String),
+              'id': int.parse(state.pathParameters['userId'] ?? '-1'),
             },
             child: BlocProvider(
               create: (context) => FollowBloc(
                 userRepository: context.read<IUserRepository>(),
-                userId: int.parse(state.pathParameters['userId'] as String),
+                userId: int.parse(state.pathParameters['userId'] ?? '-1'),
                 mode: (state.uri.queryParameters['mode'])!.followModeEnum,
               ),
               child: FollowPage(

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,3 +1,5 @@
+library child_goods_store_flutter_app_router;
+
 import 'package:child_goods_store_flutter/GA/ga_route_observer.dart';
 import 'package:child_goods_store_flutter/blocs/auth/auth_bloc_singleton.dart';
 import 'package:child_goods_store_flutter/blocs/chat/list/chat_list_bloc.dart';
@@ -45,8 +47,8 @@ import 'package:child_goods_store_flutter/pages/edit_review/edit_review_page.dar
 import 'package:child_goods_store_flutter/pages/edit_tag/edit_tag_page.dart';
 import 'package:child_goods_store_flutter/pages/edit_together/edit_together_page.dart';
 import 'package:child_goods_store_flutter/pages/follow/follow_page.dart';
-import 'package:child_goods_store_flutter/pages/home/home_page.dart';
 import 'package:child_goods_store_flutter/pages/notification/notification_page.dart';
+import 'package:child_goods_store_flutter/pages/product/product_page.dart';
 import 'package:child_goods_store_flutter/pages/product_detail/product_detail_page.dart';
 import 'package:child_goods_store_flutter/pages/profile/profile_page.dart';
 import 'package:child_goods_store_flutter/pages/settings/settings_page.dart';
@@ -74,6 +76,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
+
+/// Seperate [_appHomeRoute]
+part 'app_home_route.dart';
 
 class AppRouter extends StatefulWidget {
   const AppRouter({super.key});
@@ -121,7 +126,7 @@ class _AppRouterState extends State<AppRouter> {
         }
         if (authState.authStatus == EAuthStatus.authenticated) {
           return blockPageInAuthState.contains(state.uri.toString())
-              ? Routes.home
+              ? Routes.product
               : state.uri.toString();
         }
         return state.uri.toString();
@@ -227,148 +232,7 @@ class _AppRouterState extends State<AppRouter> {
             ),
           ),
         ),
-        StatefulShellRoute.indexedStack(
-          pageBuilder: (context, state, navigationShell) =>
-              PageTransition.cupertino(
-            key: state.pageKey,
-            // ignore `name` field for disable GA
-            child: Scaffold(
-              body: navigationShell,
-              bottomNavigationBar: Container(
-                height: Sizes.size60 + MediaQuery.paddingOf(context).bottom,
-                decoration: BoxDecoration(
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      blurRadius: Sizes.size3,
-                      spreadRadius: Sizes.size1,
-                    ),
-                  ],
-                ),
-                child: BottomNavigationBar(
-                  enableFeedback: false,
-                  type: BottomNavigationBarType.fixed,
-                  unselectedLabelStyle: const TextStyle(fontSize: Sizes.size8),
-                  selectedLabelStyle: const TextStyle(fontSize: Sizes.size10),
-                  selectedIconTheme: const IconThemeData(size: Sizes.size28),
-                  items: [
-                    const BottomNavigationBarItem(
-                      label: '중고거래',
-                      icon: Icon(Icons.home),
-                    ),
-                    BottomNavigationBarItem(
-                      label: '공동구매',
-                      icon: Transform.scale(
-                        scale: 0.8,
-                        child: const Icon(FontAwesomeIcons.boxesStacked),
-                      ),
-                    ),
-                    const BottomNavigationBarItem(
-                      label: '자녀',
-                      icon: Icon(Icons.child_care_rounded),
-                    ),
-                    const BottomNavigationBarItem(
-                      label: '채팅',
-                      icon: Icon(Icons.chat_rounded),
-                    ),
-                    const BottomNavigationBarItem(
-                      label: '내 정보',
-                      icon: Icon(Icons.person_rounded),
-                    ),
-                  ],
-                  currentIndex: navigationShell.currentIndex,
-                  onTap: (value) => navigationShell.goBranch(value),
-                ),
-              ),
-            ),
-          ),
-          branches: [
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  name: Routes.home,
-                  path: Routes.home,
-                  builder: (context, state) => BlocProvider(
-                    create: (context) => ProductListBloc(
-                      productRepository: context.read<IProductRepository>(),
-                    ),
-                    child: const HomePage(),
-                  ),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  name: Routes.together,
-                  path: Routes.together,
-                  builder: (context, state) => BlocProvider(
-                    create: (context) => TogetherListBloc(
-                      togetherRepository: context.read<ITogetherRepository>(),
-                    ),
-                    child: const TogetherPage(),
-                  ),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  name: Routes.child,
-                  path: Routes.child,
-                  builder: (context, state) => BlocProvider(
-                    create: (context) => ChildBloc(
-                      childRepository: context.read<IChildRepository>(),
-                    ),
-                    child: const ChildPage(),
-                  ),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  name: Routes.chat,
-                  path: Routes.chat,
-                  builder: (context, state) => BlocProvider(
-                    create: (context) => ChatListBloc(
-                      chatRepository: context.read<IChatRepository>(),
-                    ),
-                    child: const ChatPage(),
-                  ),
-                ),
-              ],
-            ),
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  name: Routes.profile,
-                  path: Routes.profile,
-                  builder: (context, state) => MultiBlocProvider(
-                    providers: [
-                      BlocProvider(
-                        create: (context) => ProfileBloc(
-                          userRepository: context.read<IUserRepository>(),
-                          userId: AuthBlocSingleton.bloc.state.user!.userId!,
-                        ),
-                      ),
-                      BlocProvider(
-                        create: (context) => ProfileTabBloc(
-                          profileRepository: context.read<IProfileRepository>(),
-                          reviewRepository: context.read<IReviewRepository>(),
-                          userId: AuthBlocSingleton.bloc.state.user!.userId!,
-                        ),
-                      ),
-                    ],
-                    child: const ProfilePage(
-                      popAble: false,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
+        _appHomeRoute(),
         GoRoute(
           path: '${Routes.productDetail}/:productId',
           pageBuilder: (context, state) => PageTransition.cupertino(
@@ -565,25 +429,7 @@ class _AppRouterState extends State<AppRouter> {
             ),
           ),
         ),
-        GoRoute(
-          path: Routes.chatRoom,
-          pageBuilder: (context, state) => PageTransition.cupertino(
-            key: state.pageKey,
-            name: state.fullPath,
-            arguments: {
-              'id': (state.extra as GoRouterExtraModel<int>).data ?? -1
-            },
-            child: BlocProvider(
-              create: (context) => ChatRoomBloc(
-                chatRepository: context.read<IChatRepository>(),
-                productRepository: context.read<IProductRepository>(),
-                togetherRepository: context.read<ITogetherRepository>(),
-                chatRoomId: (state.extra as GoRouterExtraModel<int>).data ?? -1,
-              ),
-              child: const ChatRoomPage(),
-            ),
-          ),
-        ),
+
         GoRoute(
           path: Routes.settings,
           pageBuilder: (context, state) => PageTransition.cupertino(
@@ -655,21 +501,9 @@ class _AppRouterState extends State<AppRouter> {
         Locale('en'),
       ],
       locale: const Locale('ko'),
-      builder: (context, child) => BlocListener<FCMCubit, FCMState>(
-        bloc: FCMCubitSingleton.cubit,
-        listener: (context, state) {
-          if (state.data != null) {
-            // TODO: Replace event
-            AppSnackbar.show(
-              context,
-              message: state.body ?? Strings.unknownFail,
-            );
-          }
-        },
-        child: _flavorBanner(
-          child: child ?? const SizedBox(),
-          show: F.appFlavor != Flavor.prod,
-        ),
+      builder: (context, child) => _flavorBanner(
+        child: child ?? const SizedBox(),
+        show: F.appFlavor != Flavor.prod,
       ),
     );
   }

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -253,6 +253,7 @@ class _AppRouterState extends State<AppRouter> {
             child: BlocProvider(
               create: (context) => ProductDetailBloc(
                 productRepository: context.read<IProductRepository>(),
+                chatRepository: context.read<IChatRepository>(),
                 productId: int.parse(state.pathParameters['productId'] ?? '-1'),
               ),
               child: const ProductDetailPage(),

--- a/lib/blocs/chat/room/chat_room_event.dart
+++ b/lib/blocs/chat/room/chat_room_event.dart
@@ -9,3 +9,5 @@ class ChatRoomSendChat extends ChatRoomEvent {
 
   ChatRoomSendChat(this.message);
 }
+
+class ChatRoomInitStomp extends ChatRoomEvent {}

--- a/lib/blocs/chat/room/chat_room_state.dart
+++ b/lib/blocs/chat/room/chat_room_state.dart
@@ -13,6 +13,8 @@ class ChatRoomState extends BlocState {
   final TogetherModel? targetTogether;
   final ELoadingStatus targetStatus;
   final String? targetErrMessage;
+  final ELoadingStatus stompStatus;
+  final String? stompErrMessage;
 
   const ChatRoomState({
     required this.page,
@@ -23,6 +25,8 @@ class ChatRoomState extends BlocState {
     this.targetTogether,
     required this.targetStatus,
     this.targetErrMessage,
+    required this.stompStatus,
+    this.stompErrMessage,
     required super.status,
     super.message,
   });
@@ -36,6 +40,8 @@ class ChatRoomState extends BlocState {
         targetTogether = null,
         targetStatus = ELoadingStatus.init,
         targetErrMessage = null,
+        stompStatus = ELoadingStatus.init,
+        stompErrMessage = null,
         super(
           status: ELoadingStatus.init,
           message: null,
@@ -53,6 +59,8 @@ class ChatRoomState extends BlocState {
     TogetherModel? targetTogether,
     ELoadingStatus? targetStatus,
     String? targetErrMessage,
+    ELoadingStatus? stompStatus,
+    String? stompErrMessage,
   }) =>
       ChatRoomState(
         page: page ?? this.page,
@@ -63,6 +71,8 @@ class ChatRoomState extends BlocState {
         targetTogether: targetTogether ?? this.targetTogether,
         targetStatus: targetStatus ?? this.targetStatus,
         targetErrMessage: targetErrMessage ?? this.targetErrMessage,
+        stompStatus: stompStatus ?? this.stompStatus,
+        stompErrMessage: stompErrMessage ?? this.stompErrMessage,
         status: status ?? this.status,
         message: message ?? this.message,
       );
@@ -77,6 +87,8 @@ class ChatRoomState extends BlocState {
         targetTogether,
         targetStatus,
         targetErrMessage,
+        stompStatus,
+        stompErrMessage,
         status,
         message,
       ];

--- a/lib/blocs/fcm/fcm_cubit.dart
+++ b/lib/blocs/fcm/fcm_cubit.dart
@@ -43,9 +43,9 @@ class FCMState extends Equatable {
   /// 푸쉬 알림에서 보여지는 문자열
   final String? body;
 
-  /// FCM의 data 객체 데이터를 저장하는 객체
-  /// code: 어떤 타입의 데이터인지 정의
-  /// message: 문자열로 인코딩된 json 데이터. 파싱 방법은 code에 따라 상이.
+  /// FCM의 data 객체 데이터를 저장하는 객체 \
+  /// [code]: 어떤 타입의 데이터인지 정의 \
+  /// [message]: 문자열로 인코딩된 json 데이터. 파싱 방법은 code에 따라 상이.
   final ResModel? data;
 
   const FCMState({

--- a/lib/blocs/fcm/fcm_cubit.dart
+++ b/lib/blocs/fcm/fcm_cubit.dart
@@ -16,13 +16,25 @@ class FCMCubit extends Cubit<FCMState> {
     // at background
     FirebaseMessaging.onMessageOpenedApp.listen(listenFCM);
     // at terminate
-    FirebaseMessaging.instance.getInitialMessage().then(listenFCM);
+    FirebaseMessaging.instance.getInitialMessage().then((msg) => listenFCM(
+          msg,
+          afterReset: false,
+        ));
   }
 
-  void listenFCM(RemoteMessage? message) {
+  void listenFCM(
+    RemoteMessage? message, {
+    bool afterReset = true,
+  }) {
     if (message != null && fcmToken != Strings.nullStr) {
       emit(FCMState.fromRemoteMessage(message));
     }
+    if (afterReset) {
+      emit(const FCMState());
+    }
+  }
+
+  void resetFCM() {
     emit(const FCMState());
   }
 }

--- a/lib/blocs/product/detail/product_detail_event.dart
+++ b/lib/blocs/product/detail/product_detail_event.dart
@@ -15,3 +15,5 @@ class ProductDetailChangeSaleState extends ProductDetailEvent {
 }
 
 class ProductDetailChangeHeart extends ProductDetailEvent {}
+
+class ProductDetailChat extends ProductDetailEvent {}

--- a/lib/blocs/product/detail/product_detail_state.dart
+++ b/lib/blocs/product/detail/product_detail_state.dart
@@ -7,12 +7,16 @@ class ProductDetailState extends BlocState {
   final ELoadingStatus productStatus;
   final ELoadingStatus changeSaleStatus;
   final ELoadingStatus heartStatus;
+  final int? chatRoomIdResult;
+  final ELoadingStatus chatStatus;
 
   const ProductDetailState({
     this.productModel,
     required this.productStatus,
     required this.changeSaleStatus,
     required this.heartStatus,
+    this.chatRoomIdResult,
+    required this.chatStatus,
     required super.status,
     super.message,
   });
@@ -22,6 +26,8 @@ class ProductDetailState extends BlocState {
         productStatus = ELoadingStatus.init,
         changeSaleStatus = ELoadingStatus.init,
         heartStatus = ELoadingStatus.init,
+        chatRoomIdResult = null,
+        chatStatus = ELoadingStatus.init,
         super(
           status: ELoadingStatus.init,
           message: null,
@@ -35,6 +41,8 @@ class ProductDetailState extends BlocState {
     ELoadingStatus? productStatus,
     ELoadingStatus? changeSaleStatus,
     ELoadingStatus? heartStatus,
+    int? chatRoomIdResult,
+    ELoadingStatus? chatStatus,
   }) =>
       ProductDetailState(
         status: status ?? this.status,
@@ -43,6 +51,8 @@ class ProductDetailState extends BlocState {
         productStatus: productStatus ?? this.productStatus,
         changeSaleStatus: changeSaleStatus ?? this.changeSaleStatus,
         heartStatus: heartStatus ?? this.heartStatus,
+        chatRoomIdResult: chatRoomIdResult ?? this.chatRoomIdResult,
+        chatStatus: chatStatus ?? this.chatStatus,
       );
 
   @override
@@ -53,5 +63,7 @@ class ProductDetailState extends BlocState {
         productStatus,
         changeSaleStatus,
         heartStatus,
+        chatRoomIdResult,
+        chatStatus,
       ];
 }

--- a/lib/configs/configs.dart
+++ b/lib/configs/configs.dart
@@ -4,11 +4,16 @@ import 'package:child_goods_store_flutter/flavors.dart';
 class Configs {
   // Add configs here
   final String baseUrl;
+  final String wsUrl;
 
   // Initialize configs here
-  Configs._dev() : baseUrl = Networks.devBaseUrl;
+  Configs._dev()
+      : baseUrl = Networks.devBaseUrl,
+        wsUrl = Networks.devWsUrl;
 
-  Configs._prod() : baseUrl = Networks.baseUrl;
+  Configs._prod()
+      : baseUrl = Networks.baseUrl,
+        wsUrl = Networks.wsUrl;
 
   factory Configs(Flavor? flavor) {
     switch (flavor) {

--- a/lib/constants/networks.dart
+++ b/lib/constants/networks.dart
@@ -3,4 +3,7 @@ import 'package:child_goods_store_flutter/constants/secret.dart';
 class Networks {
   static const String devBaseUrl = 'dev base url';
   static const String baseUrl = Secret.baseUrl;
+
+  static const String devWsUrl = 'ws://localhost:8080/ws';
+  static const String wsUrl = Secret.wsUrl;
 }

--- a/lib/constants/routes.dart
+++ b/lib/constants/routes.dart
@@ -39,12 +39,7 @@ class Routes {
   /// ReviewModel: previous review data
   static const String editReview = '/edit_review';
 
-  /// ### Extra - Required
-  /// extra: GoRouterExtraModel\<int\> \
-  /// int: [chatRoomId]
-  static const String chatRoom = '/chat_room';
-
-  static const String home = '/home';
+  static const String product = '/product';
   static const String together = '/together';
   static const String child = '/child';
   static const String chat = '/chat';
@@ -59,4 +54,9 @@ class Routes {
 class SubRoutes {
   static const String ship = 'ship';
   static const String notification = 'notification';
+
+  /// ### Extra - Required
+  /// extra: GoRouterExtraModel\<int\> \
+  /// int: [chatRoomId]
+  static const String chatRoom = 'chat_room';
 }

--- a/lib/constants/routes.dart
+++ b/lib/constants/routes.dart
@@ -45,9 +45,19 @@ class Routes {
   static const String chat = '/chat';
   static const String profile = '/profile';
 
+  /// ### Path parameter - Required
+  /// `/:productId` [int]
   static const String productDetail = '/product';
+
+  /// ### Path parameter - Required
+  /// `/:togetherId` [int]
   static const String togetherDetail = '/together';
 
+  /// ### Path parameter - Required
+  /// `/:userId` [int]
+  ///
+  /// ### Query parameter - Required
+  /// `?mode=EFollowMode.key`
   static const String follow = '/follow';
 }
 
@@ -55,8 +65,7 @@ class SubRoutes {
   static const String ship = 'ship';
   static const String notification = 'notification';
 
-  /// ### Extra - Required
-  /// extra: GoRouterExtraModel\<int\> \
-  /// int: [chatRoomId]
+  /// ### Path parameter - Required
+  /// `/:chatRoomId` [int]
   static const String chatRoom = 'chat_room';
 }

--- a/lib/pages/chat/chat_page.dart
+++ b/lib/pages/chat/chat_page.dart
@@ -26,23 +26,21 @@ class ChatPage extends StatelessWidget {
         title: const AppFont('채팅'),
         elevation: Sizes.size1,
       ),
-      body: SafeArea(
-        child: BlocBuilder<ChatListBloc, ChatListState>(
-          builder: (context, state) {
-            if (state.status == ELoadingStatus.loaded) {
-              return _buildBody(context, state: state);
-            }
-            if (state.status == ELoadingStatus.error) {
-              return _buildError(
-                context,
-                message: state.message ?? Strings.unknownFail,
-              );
-            }
-            return const Center(
-              child: CircularProgressIndicator(),
+      body: BlocBuilder<ChatListBloc, ChatListState>(
+        builder: (context, state) {
+          if (state.status == ELoadingStatus.loaded) {
+            return _buildBody(context, state: state);
+          }
+          if (state.status == ELoadingStatus.error) {
+            return _buildError(
+              context,
+              message: state.message ?? Strings.unknownFail,
             );
-          },
-        ),
+          }
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        },
       ),
     );
   }
@@ -52,6 +50,7 @@ class ChatPage extends StatelessWidget {
     required ChatListState state,
   }) {
     return ListView.separated(
+      padding: EdgeInsets.zero,
       itemBuilder: (context, index) => ChatRoomWidget(
         chatRoom: state.chatRooms[index],
       ),

--- a/lib/pages/chat/widgets/chat_room_widget.dart
+++ b/lib/pages/chat/widgets/chat_room_widget.dart
@@ -20,8 +20,8 @@ class ChatRoomWidget extends StatelessWidget {
   });
 
   void _onTapChatRoom(BuildContext context) {
-    context.push(
-      Routes.chatRoom,
+    context.go(
+      '${Routes.chat}/${SubRoutes.chatRoom}',
       extra: GoRouterExtraModel<int>(data: chatRoom.id),
     );
   }

--- a/lib/pages/chat/widgets/chat_room_widget.dart
+++ b/lib/pages/chat/widgets/chat_room_widget.dart
@@ -4,7 +4,6 @@ import 'package:child_goods_store_flutter/constants/sizes.dart';
 import 'package:child_goods_store_flutter/constants/strings.dart';
 import 'package:child_goods_store_flutter/enums/chat_item_type.dart';
 import 'package:child_goods_store_flutter/models/chat/chat_room_model.dart';
-import 'package:child_goods_store_flutter/models/go_router_extra_model.dart';
 import 'package:child_goods_store_flutter/utils/time_utils.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
@@ -20,10 +19,7 @@ class ChatRoomWidget extends StatelessWidget {
   });
 
   void _onTapChatRoom(BuildContext context) {
-    context.go(
-      '${Routes.chat}/${SubRoutes.chatRoom}',
-      extra: GoRouterExtraModel<int>(data: chatRoom.id),
-    );
+    context.go('${Routes.chat}/${SubRoutes.chatRoom}/${chatRoom.id}');
   }
 
   @override

--- a/lib/pages/chat_room/chat_room_page.dart
+++ b/lib/pages/chat_room/chat_room_page.dart
@@ -61,6 +61,10 @@ class _ChatRoomPageState extends State<ChatRoomPage> {
     context.read<ChatRoomBloc>().add(ChatRoomGetItem());
   }
 
+  void _onTapRetryChatConnect() {
+    context.read<ChatRoomBloc>().add(ChatRoomInitStomp());
+  }
+
   void _unfocus() {
     FocusScope.of(context).unfocus();
     FocusManager.instance.primaryFocus?.unfocus();
@@ -173,12 +177,44 @@ class _ChatRoomPageState extends State<ChatRoomPage> {
         bottomSheet: SafeArea(
           child: BlocBuilder<ChatRoomBloc, ChatRoomState>(
             buildWhen: (previous, current) =>
-                previous.targetStatus != current.targetStatus,
+                previous.targetStatus != current.targetStatus ||
+                previous.stompStatus != current.stompStatus,
             builder: (context, state) {
               if (state.targetStatus != ELoadingStatus.loaded) {
                 return const SizedBox();
               }
-              return const ChatSendBox();
+              if (state.stompStatus == ELoadingStatus.loaded) {
+                return const ChatSendBox();
+              }
+              if (state.stompStatus == ELoadingStatus.error) {
+                return Container(
+                  width: double.infinity,
+                  decoration: BoxDecoration(
+                    color: Colors.red,
+                    boxShadow: [
+                      BoxShadow(
+                        blurRadius: Sizes.size1 / 2,
+                        spreadRadius: Sizes.size1 / 2,
+                        offset: const Offset(0, -Sizes.size2),
+                        color: Colors.black.withOpacity(0.2),
+                      ),
+                    ],
+                  ),
+                  child: AppInkButton(
+                    onTap: _onTapRetryChatConnect,
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    color: Colors.transparent,
+                    shadowColor: Colors.transparent,
+                    child: const AppFont(
+                      '채팅서버 연결에 실패했습니다.\n터치하여 재 연결을 시도해주세요.',
+                      textAlign: TextAlign.center,
+                      fontSize: Sizes.size12,
+                      color: Colors.white,
+                    ),
+                  ),
+                );
+              }
+              return const SizedBox();
             },
           ),
         ),

--- a/lib/pages/chat_room/chat_room_page.dart
+++ b/lib/pages/chat_room/chat_room_page.dart
@@ -99,6 +99,7 @@ class _ChatRoomPageState extends State<ChatRoomPage> {
             },
           ),
         ),
+        resizeToAvoidBottomInset: false,
         body: SafeArea(
           child: CustomScrollView(
             controller: _scrollController,
@@ -169,11 +170,7 @@ class _ChatRoomPageState extends State<ChatRoomPage> {
             ],
           ),
         ),
-        bottomSheet: Container(
-          color: Theme.of(context).scaffoldBackgroundColor,
-          padding: EdgeInsets.only(
-            bottom: MediaQuery.paddingOf(context).bottom,
-          ),
+        bottomSheet: SafeArea(
           child: BlocBuilder<ChatRoomBloc, ChatRoomState>(
             buildWhen: (previous, current) =>
                 previous.targetStatus != current.targetStatus,

--- a/lib/pages/child/child_page.dart
+++ b/lib/pages/child/child_page.dart
@@ -63,24 +63,22 @@ class _ChildPageState extends State<ChildPage> {
         title: const AppFont('자녀 맞춤추천'),
         elevation: Sizes.size1,
       ),
-      body: SafeArea(
-        child: BlocBuilder<ChildBloc, ChildState>(
-          builder: (context, state) {
-            if (state.childListStatus == ELoadingStatus.loaded) {
-              return _buildBody(context, state: state);
-            }
-            if (state.status == ELoadingStatus.error &&
-                state.childListStatus == ELoadingStatus.loading) {
-              return _buildError(
-                context,
-                message: state.message ?? Strings.unknownFail,
-              );
-            }
-            return const Center(
-              child: CircularProgressIndicator(),
+      body: BlocBuilder<ChildBloc, ChildState>(
+        builder: (context, state) {
+          if (state.childListStatus == ELoadingStatus.loaded) {
+            return _buildBody(context, state: state);
+          }
+          if (state.status == ELoadingStatus.error &&
+              state.childListStatus == ELoadingStatus.loading) {
+            return _buildError(
+              context,
+              message: state.message ?? Strings.unknownFail,
             );
-          },
-        ),
+          }
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        },
       ),
     );
   }

--- a/lib/pages/edit_address/edit_address_page.dart
+++ b/lib/pages/edit_address/edit_address_page.dart
@@ -173,7 +173,7 @@ class _EditAddressPageState extends State<EditAddressPage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading

--- a/lib/pages/edit_product/edit_product_page.dart
+++ b/lib/pages/edit_product/edit_product_page.dart
@@ -158,7 +158,7 @@ class _EditProductPageState extends State<EditProductPage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading

--- a/lib/pages/edit_profile/edit_profile_page.dart
+++ b/lib/pages/edit_profile/edit_profile_page.dart
@@ -104,7 +104,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
         }
         if (state.status == ELoadingStatus.loaded) {
           if (context.read<EditProfileBloc>().httpMethod == EHttpMethod.post) {
-            context.pushReplacement(Routes.home);
+            context.go(Routes.product);
           } else {
             context.pop();
           }

--- a/lib/pages/edit_profile/edit_profile_page.dart
+++ b/lib/pages/edit_profile/edit_profile_page.dart
@@ -235,7 +235,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading

--- a/lib/pages/edit_review/edit_review_page.dart
+++ b/lib/pages/edit_review/edit_review_page.dart
@@ -105,7 +105,7 @@ class _EditReviewPageState extends State<EditReviewPage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.reviewStatus == ELoadingStatus.loading

--- a/lib/pages/edit_tag/edit_tag_page.dart
+++ b/lib/pages/edit_tag/edit_tag_page.dart
@@ -118,7 +118,7 @@ class _EditTagPageState extends State<EditTagPage> {
           width: double.infinity,
           height: Sizes.size60,
           margin: EdgeInsets.only(
-            bottom: MediaQuery.paddingOf(context).bottom,
+            bottom: MediaQuery.viewPaddingOf(context).bottom,
           ),
           child: const Center(
             child: AppFont(

--- a/lib/pages/edit_together/edit_together_page.dart
+++ b/lib/pages/edit_together/edit_together_page.dart
@@ -209,7 +209,7 @@ class _EditTogetherPageState extends State<EditTogetherPage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading

--- a/lib/pages/notification/notification_page.dart
+++ b/lib/pages/notification/notification_page.dart
@@ -1,4 +1,6 @@
+import 'package:child_goods_store_flutter/constants/gaps.dart';
 import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/pages/notification/widgets/notification_listitem.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:flutter/material.dart';
 
@@ -13,12 +15,74 @@ class NotificationPage extends StatelessWidget {
         centerTitle: false,
       ),
       resizeToAvoidBottomInset: false,
-      body: const SingleChildScrollView(
+      body: SingleChildScrollView(
         child: Padding(
-          padding: EdgeInsets.all(Sizes.size20),
+          padding: const EdgeInsets.all(Sizes.size20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [],
+            children: [
+              NotificationListItem(
+                title: '전체 알림',
+                onState: true,
+                onChanged: (value) {},
+              ),
+              Gaps.v20,
+              NotificationListItem(
+                title: '채팅',
+                onState: true,
+                onChanged: (value) {},
+              ),
+              NotificationListItem(
+                title: '팔로우',
+                onState: true,
+                onChanged: (value) {},
+              ),
+              Gaps.v20,
+              const AppFont('중고거래'),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: Sizes.size20,
+                  top: Sizes.size10,
+                ),
+                child: Column(
+                  children: [
+                    NotificationListItem(
+                      title: '찜',
+                      onState: true,
+                      onChanged: (value) {},
+                    ),
+                    NotificationListItem(
+                      title: '후기 알림',
+                      onState: true,
+                      onChanged: (value) {},
+                    ),
+                  ],
+                ),
+              ),
+              Gaps.v20,
+              const AppFont('공동구매'),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: Sizes.size20,
+                  top: Sizes.size10,
+                ),
+                child: Column(
+                  children: [
+                    NotificationListItem(
+                      title: '참여자 추가',
+                      onState: true,
+                      onChanged: (value) {},
+                    ),
+                    NotificationListItem(
+                      title: '후기 알림',
+                      onState: true,
+                      onChanged: (value) {},
+                    ),
+                  ],
+                ),
+              ),
+              SizedBox(height: MediaQuery.viewPaddingOf(context).bottom),
+            ],
           ),
         ),
       ),

--- a/lib/pages/notification/widgets/notification_listitem.dart
+++ b/lib/pages/notification/widgets/notification_listitem.dart
@@ -1,0 +1,68 @@
+import 'package:child_goods_store_flutter/constants/sizes.dart';
+import 'package:child_goods_store_flutter/widgets/app_font.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_advanced_switch/flutter_advanced_switch.dart';
+
+class NotificationListItem extends StatefulWidget {
+  final String title;
+  final bool onState;
+  final Function(bool) onChanged;
+
+  const NotificationListItem({
+    super.key,
+    required this.title,
+    required this.onState,
+    required this.onChanged,
+  });
+
+  @override
+  State<NotificationListItem> createState() => _NotificationListItemState();
+}
+
+class _NotificationListItemState extends State<NotificationListItem> {
+  late final ValueNotifier<bool> _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ValueNotifier(widget.onState);
+  }
+
+  @override
+  void didUpdateWidget(covariant NotificationListItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.onState != widget.onState) {
+      _controller.value = widget.onState;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        vertical: Sizes.size5,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          AppFont(widget.title),
+          AdvancedSwitch(
+            controller: _controller,
+            initialValue: widget.onState,
+            onChanged: (value) {
+              _controller.value = value;
+              widget.onChanged.call(value);
+            },
+            height: Sizes.size24,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/phone_verify/phone_verify_page.dart
+++ b/lib/pages/phone_verify/phone_verify_page.dart
@@ -92,7 +92,7 @@ class _PhoneVerifyPageState extends State<PhoneVerifyPage> {
                 width: double.infinity,
                 height: Sizes.size32,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading

--- a/lib/pages/product/product_page.dart
+++ b/lib/pages/product/product_page.dart
@@ -8,7 +8,7 @@ import 'package:child_goods_store_flutter/constants/strings.dart';
 import 'package:child_goods_store_flutter/enums/loading_status.dart';
 import 'package:child_goods_store_flutter/flavors.dart';
 import 'package:child_goods_store_flutter/models/go_router_extra_model.dart';
-import 'package:child_goods_store_flutter/pages/home/widgets/home_app_bar.dart';
+import 'package:child_goods_store_flutter/pages/product/widgets/product_app_bar.dart';
 import 'package:child_goods_store_flutter/widgets/app_font.dart';
 import 'package:child_goods_store_flutter/widgets/app_ink_button.dart';
 import 'package:child_goods_store_flutter/widgets/app_snackbar.dart';
@@ -17,14 +17,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
-class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+class ProductPage extends StatefulWidget {
+  const ProductPage({super.key});
 
   @override
-  State<HomePage> createState() => _HomePageState();
+  State<ProductPage> createState() => _ProductPageState();
 }
 
-class _HomePageState extends State<HomePage> {
+class _ProductPageState extends State<ProductPage> {
   late ScrollController _scrollController;
 
   @override
@@ -89,7 +89,7 @@ class _HomePageState extends State<HomePage> {
         controller: _scrollController,
         slivers: [
           const SliverAppBar(
-            flexibleSpace: HomeAppBar(),
+            flexibleSpace: ProductAppBar(),
             collapsedHeight: 210,
             floating: true,
             snap: true,

--- a/lib/pages/product/widgets/product_app_bar.dart
+++ b/lib/pages/product/widgets/product_app_bar.dart
@@ -6,21 +6,21 @@ import 'package:child_goods_store_flutter/constants/sizes.dart';
 import 'package:child_goods_store_flutter/enums/main_category.dart';
 import 'package:child_goods_store_flutter/enums/search_range.dart';
 import 'package:child_goods_store_flutter/enums/sub_category.dart';
-import 'package:child_goods_store_flutter/pages/home/widgets/home_app_bar_filters.dart';
+import 'package:child_goods_store_flutter/pages/product/widgets/product_app_bar_filters.dart';
 import 'package:child_goods_store_flutter/widgets/app_dropdown.dart';
 import 'package:child_goods_store_flutter/widgets/app_h_spliter.dart';
 import 'package:child_goods_store_flutter/widgets/common/v_icon_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class HomeAppBar extends StatefulWidget {
-  const HomeAppBar({super.key});
+class ProductAppBar extends StatefulWidget {
+  const ProductAppBar({super.key});
 
   @override
-  State<HomeAppBar> createState() => _HomeAppBarState();
+  State<ProductAppBar> createState() => _ProductAppBarState();
 }
 
-class _HomeAppBarState extends State<HomeAppBar> {
+class _ProductAppBarState extends State<ProductAppBar> {
   static const String _allCategory = '전체';
 
   void _onChangeMainCategory(String? mainCat) {
@@ -111,7 +111,7 @@ class _HomeAppBarState extends State<HomeAppBar> {
               ),
             ),
           ),
-          const HomeAppBarFilters(),
+          const ProductAppBarFilters(),
           Gaps.v5,
           const AppHSpliter(),
         ],

--- a/lib/pages/product/widgets/product_app_bar_filters.dart
+++ b/lib/pages/product/widgets/product_app_bar_filters.dart
@@ -12,14 +12,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
-class HomeAppBarFilters extends StatefulWidget {
-  const HomeAppBarFilters({super.key});
+class ProductAppBarFilters extends StatefulWidget {
+  const ProductAppBarFilters({super.key});
 
   @override
-  State<HomeAppBarFilters> createState() => _HomeAppBarFiltersState();
+  State<ProductAppBarFilters> createState() => ProductAppBarFiltersState();
 }
 
-class _HomeAppBarFiltersState extends State<HomeAppBarFilters> {
+class ProductAppBarFiltersState extends State<ProductAppBarFilters> {
   bool _noPriceFilter(ProductListState state) {
     return state.minPrice == ProductListState.MIN_PRICE &&
         state.maxPrice == ProductListState.MAX_PRICE;

--- a/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
+++ b/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
@@ -35,6 +35,7 @@ class _ProductDetailBottomBarState extends State<ProductDetailBottomBar> {
   }) {
     AppBottomSheet.show(
       context,
+      applyBottomPadding: true,
       child: Material(
         child: Column(
           children: [
@@ -131,12 +132,14 @@ class _ProductDetailBottomBarState extends State<ProductDetailBottomBar> {
       child: BlocBuilder<ProductDetailBloc, ProductDetailState>(
         builder: (context, state) {
           if (state.productStatus != ELoadingStatus.loaded) {
-            return const SizedBox();
+            return SizedBox(
+              height: MediaQuery.viewPaddingOf(context).bottom,
+            );
           }
           return Container(
-            height: Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+            height: Sizes.size60 + MediaQuery.viewPaddingOf(context).bottom,
             padding: EdgeInsets.only(
-              bottom: MediaQuery.paddingOf(context).bottom,
+              bottom: MediaQuery.viewPaddingOf(context).bottom,
               left: Sizes.size20,
               right: Sizes.size20,
             ),

--- a/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
+++ b/lib/pages/product_detail/widgets/product_detail_bottom_bar.dart
@@ -114,7 +114,19 @@ class _ProductDetailBottomBarState extends State<ProductDetailBottomBar> {
     }
   }
 
-  void _onTapChat() {}
+  void _onTapChat() {
+    var bloc = context.read<ProductDetailBloc>();
+    if (bloc.state.chatRoomIdResult == null) {
+      bloc.add(ProductDetailChat());
+    } else {
+      _goChatRoom();
+    }
+  }
+
+  void _goChatRoom() {
+    var chatRoomId = context.read<ProductDetailBloc>().state.chatRoomIdResult;
+    context.go('${Routes.chat}/${SubRoutes.chatRoom}/$chatRoomId');
+  }
 
   bool _iamSaler(ProductDetailState state) {
     return AuthBlocSingleton.bloc.state.user?.userId ==
@@ -129,7 +141,12 @@ class _ProductDetailBottomBarState extends State<ProductDetailBottomBar> {
         productId:
             context.read<ProductDetailBloc>().state.productModel!.productId!,
       ),
-      child: BlocBuilder<ProductDetailBloc, ProductDetailState>(
+      child: BlocConsumer<ProductDetailBloc, ProductDetailState>(
+        listener: (context, state) {
+          if (state.chatStatus == ELoadingStatus.loaded) {
+            _goChatRoom();
+          }
+        },
         builder: (context, state) {
           if (state.productStatus != ELoadingStatus.loaded) {
             return SizedBox(

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -98,7 +98,7 @@ class _ProfilePageState extends State<ProfilePage>
               )
             : null,
         body: SafeArea(
-          bottom: false,
+          bottom: widget.popAble ? true : false,
           child: BlocBuilder<ProfileBloc, ProfileState>(
             builder: (context, state) {
               if (state.profileStatus == ELoadingStatus.loaded) {

--- a/lib/pages/profile/profile_page.dart
+++ b/lib/pages/profile/profile_page.dart
@@ -98,6 +98,7 @@ class _ProfilePageState extends State<ProfilePage>
               )
             : null,
         body: SafeArea(
+          bottom: false,
           child: BlocBuilder<ProfileBloc, ProfileState>(
             builder: (context, state) {
               if (state.profileStatus == ELoadingStatus.loaded) {

--- a/lib/pages/signup/signup_page.dart
+++ b/lib/pages/signup/signup_page.dart
@@ -222,7 +222,7 @@ class _SignupPageState extends State<SignupPage> {
                 width: double.infinity,
                 height: Sizes.size60,
                 margin: EdgeInsets.only(
-                  bottom: MediaQuery.paddingOf(context).bottom,
+                  bottom: MediaQuery.viewPaddingOf(context).bottom,
                 ),
                 child: Center(
                   child: state.status == ELoadingStatus.loading &&

--- a/lib/pages/together_detail/widgets/together_detail_bottom_bar.dart
+++ b/lib/pages/together_detail/widgets/together_detail_bottom_bar.dart
@@ -67,9 +67,9 @@ class _TogetherDetailBottomBarState extends State<TogetherDetailBottomBar> {
           return const SizedBox();
         }
         return Container(
-          height: Sizes.size60 + MediaQuery.paddingOf(context).bottom,
+          height: Sizes.size60 + MediaQuery.viewPaddingOf(context).bottom,
           padding: EdgeInsets.only(
-            bottom: MediaQuery.paddingOf(context).bottom,
+            bottom: MediaQuery.viewPaddingOf(context).bottom,
             left: Sizes.size20,
             right: Sizes.size20,
           ),

--- a/lib/repositories/dev/product_repository_impl_dev.dart
+++ b/lib/repositories/dev/product_repository_impl_dev.dart
@@ -86,7 +86,7 @@ class ProductRepositoryImplDev implements IProductRepository {
       data: ProductModel(
         productId: productId,
         user: UserProfileModel(
-          userId: 1, // 분기
+          userId: productId, // 분기
           nickName: 'product $productId saler',
           averageStars: 4.5,
         ),

--- a/lib/widgets/app_bottom_sheet.dart
+++ b/lib/widgets/app_bottom_sheet.dart
@@ -11,13 +11,17 @@ class AppBottomSheet extends BottomSheet {
   static show(
     BuildContext context, {
     required Widget child,
+    bool applyBottomPadding = false,
   }) {
     showModalBottomSheet(
       context: context,
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         margin: EdgeInsets.only(
-          bottom: MediaQuery.paddingOf(context).bottom + Sizes.size20,
+          bottom: Sizes.size20 +
+              (applyBottomPadding
+                  ? MediaQuery.viewPaddingOf(context).bottom
+                  : 0),
           left: Sizes.size20,
           right: Sizes.size20,
         ),
@@ -59,7 +63,7 @@ class AppBottomSheet extends BottomSheet {
       builder: (context) {
         return Padding(
           padding: EdgeInsets.only(
-            bottom: MediaQuery.paddingOf(context).bottom + Sizes.size20,
+            bottom: MediaQuery.viewPaddingOf(context).bottom + Sizes.size20,
             left: Sizes.size20,
             right: Sizes.size20,
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,6 +430,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_advanced_switch:
+    dependency: "direct main"
+    description:
+      name: flutter_advanced_switch
+      sha256: e1147161a3dd9b708a71c65e76174d4d1a0a5908a571b8b38b65c79b142c52a0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   flutter_bloc:
     dependency: "direct main"
     description:
@@ -1194,6 +1202,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  stomp_dart_client:
+    dependency: "direct main"
+    description:
+      name: stomp_dart_client
+      sha256: "244a243c8d56dd1a64e5d27f599d7d6077866267aff506f9dd9e60630c41cba7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,8 @@ dependencies:
   percent_indicator: ^4.2.3
   extended_nested_scroll_view: ^6.2.1
   web_socket_channel: ^2.4.5
+  stomp_dart_client: ^2.0.0
+  flutter_advanced_switch: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 개요

구현 못한 채팅 관련 기능 대부분 마무리 하였습니다.
다만, Stomp 관련 채팅 로직은 아직 구현 중입니다.

미리 PR을 올리는 이유는 배포 자동화에 우선순위를 두었기 때문입니다.

Resolves: #47

### 추가사항

- [ ] 채팅 소캣 연결 (API 303)
- [x] API 304 연결
- [x] 푸쉬알림을 통한 채팅방 입장 구현
- [x] 잠재적인 무한 라우팅 이슈 해결

### 변경사항 및 이유

- routerConfig
  푸쉬알림으로부터 시작 페이지를 동적으로 보여주기 위해 라우터 세팅이 대부분 수정되었습니다.

- route chat_room
  chat_room 라우트가 서브 라우트로 변경되었습니다.
  이제 반드시 chat의 하위 라우트로 할당되게 됩니다.

- home page
  home으로 네이밍 되었던 기존 페이지가 product로 변경되었습니다.